### PR TITLE
issue 14: blurb is now a requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.3.3
 sphinx-rtd-theme==0.1.9
+blurb==1.0.4


### PR DESCRIPTION
Commiting fix for https://github.com/python/docsbuild-scripts/issues/14 as it just hit me while testing something else... (I didn't checked why blurb is needed but I got a build error telling blurb is missing). I'm now building locally with blurb==1.0.4, so far it's working.

