### PR TITLE
issue 18: run a chgrp to fix group of directories.

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -174,6 +174,7 @@ def build_one(version, isdev, quick, sphinxbuild, build_root, www_root,
                                                       gettext_language_tag)
     if not os.path.exists(target):
         os.makedirs(target, mode=0o775)
+    shell_out("chgrp -R {group} {file}".format(group=group, file=target))
     logging.info("Doc autobuild started in %s", checkout)
     os.chdir(checkout)
 


### PR DESCRIPTION
I see something like:

    drwxr-xr-x 19 docsbuild docs      4.0K Jul 10 04:26 3.5
    drwxr-xr-x 19 docsbuild docs      4.0K Jul 10 05:05 3.6
    drwxrwx--- 19 docsbuild docsbuild 4.0K Aug  1 23:19 3.7

With the chmod of https://github.com/python/docsbuild-scripts/pull/19
and this chgrp everything should be fixed.