### PR TITLE
bpo-31737: Bump sphinx version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytz==2017.2
 requests==2.17.3
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.6.2
+Sphinx==1.6.4
 sphinx-rtd-theme==0.1.9
 blurb==1.0.4
 sphinxcontrib-websupport==1.0.1


### PR DESCRIPTION
The issue https://bugs.python.org/issue31737 looks fixed in sphinx 1.6.3, and sphinx 1.6.4 has also been released, so maybe time to upgrade,

I tried a local build, https://bugs.python.org/issue31589 is not fixed, but everything else went well.
