### PR TITLE
Use different cpython clones to build different languages.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,9 @@
 This repository contains scripts for automatically building the Python
 documentation on docs.python.org.
+
+# How to test it?
+
+    $ mkdir www logs build_root
+    $ python3 -m venv build_root/venv/
+    $ build_root/venv/bin/python -m pip install -r requirements.txt
+    $ python3 ./build_docs.py --quick --build-root build_root --www-root www --log-directory logs --group $(id -g)

--- a/build_docs.py
+++ b/build_docs.py
@@ -324,6 +324,12 @@ def parse_args():
 
 def main():
     args = parse_args()
+    if args.log_directory:
+        args.log_directory = os.path.abspath(args.log_directory)
+    if args.build_root:
+        args.build_root = os.path.abspath(args.build_root)
+    if args.www_root:
+        args.www_root = os.path.abspath(args.www_root)
     if sys.stderr.isatty():
         logging.basicConfig(format="%(levelname)s:%(message)s",
                             stream=sys.stderr)

--- a/build_docs.py
+++ b/build_docs.py
@@ -41,10 +41,10 @@ import shutil
 
 
 BRANCHES = [
-    # version, isdev
-    (3.6, False),
-    (3.7, True),
-    (2.7, False)
+    # version, git branch, isdev
+    (3.6, '3.6', False),
+    (3.7, 'master', True),
+    (2.7, '2.7', False)
 ]
 
 LANGUAGES = [
@@ -153,12 +153,14 @@ def translation_branch(locale_repo, locale_clone_dir, needed_version):
     return sorted(translated_branches, key=lambda x: abs(needed_version - x))[0]
 
 
-def build_one(version, isdev, quick, venv, build_root, www_root,
+def build_one(version, git_branch, isdev, quick, venv, build_root, www_root,
               skip_cache_invalidation=False, group='docs',
               log_directory='/var/log/docsbuild/', language=None):
     if not language:
         language = 'en'
-    checkout = build_root + "/python" + str(version).replace('.', '')
+    checkout = os.path.join(build_root, 'python{version}{lang}'.format(
+        version=str(version).replace('.', ''),
+        lang=language if language != 'en' else ''))
     logging.info("Build start for version: %s, language: %s",
                  str(version), language)
     sphinxopts = ''
@@ -189,11 +191,9 @@ def build_one(version, isdev, quick, venv, build_root, www_root,
     except (PermissionError, subprocess.CalledProcessError) as err:
         logging.warning("Can't change mod or group of %s: %s",
                         target, str(err))
+    git_clone('https://github.com/python/cpython.git',
+              checkout, git_branch)
     os.chdir(checkout)
-
-    logging.info("Updating checkout")
-    shell_out("git reset --hard HEAD")
-    shell_out("git pull --ff-only")
     maketarget = "autobuild-" + ("dev" if isdev else "stable") + ("-html" if quick else "")
     logging.info("Running make %s", maketarget)
     logname = "{}-{}.log".format(os.path.basename(checkout), language)
@@ -340,7 +340,7 @@ def main():
     logging.root.setLevel(logging.DEBUG)
     venv = os.path.join(args.build_root, "venv")
     if args.branch:
-        branches_to_do = [(args.branch, args.devel)]
+        branches_to_do = [(args.branch, args.branch, args.devel)]
     else:
         branches_to_do = BRANCHES
     if not args.languages:
@@ -348,10 +348,10 @@ def main():
         # instead of none.  "--languages en" builds *no* translation,
         # as "en" is the untranslated one.
         args.languages = LANGUAGES
-    for version, devel in branches_to_do:
+    for version, git_branch, devel in branches_to_do:
         for language in args.languages:
             try:
-                build_one(version, devel, args.quick, venv,
+                build_one(version, git_branch, devel, args.quick, venv,
                           args.build_root, args.www_root,
                           args.skip_cache_invalidation, args.group,
                           args.log_directory, language)


### PR DESCRIPTION
This tries to fix https://bugs.python.org/issue31584 and can't hurt,
anyway the cron could have started (or would have ended up getting
started, after adding some languages) before the previous run was
complete.
