### PR TITLE
Sometimes, the latex toolchain prints non-UTF8 sequences, like a 0xa7 alone

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -117,7 +117,8 @@ def shell_out(cmd, shell=False, logfile=None):
             shell=shell,
             stdin=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            universal_newlines=True,
+            encoding="utf-8",
+            errors="backslashreplace",
         )
         if logfile:
             with open(logfile, "a+") as log:


### PR DESCRIPTION
I expect this to be fixed in newer toolchains, but as we almost never
use the output of those commands (except for logging purposes), it's
safe to use a backslashreplace.