### PR TITLE
Replace hardcoded dircmp with dircmp from stdlib.

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -31,15 +31,15 @@ Modified by Julien Palard to build translations.
 
 """
 
-from concurrent.futures import ThreadPoolExecutor, wait, ALL_COMPLETED
-from datetime import datetime
 import filecmp
 import logging
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
-import shutil
+from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
+from datetime import datetime
 
 try:
     import sentry_sdk


### PR DESCRIPTION
Tested it locally on two different builds (3.6 vs 3.7), old and new one are respectively finding 770 and 771 files. New one is finding one more file that *is* diffing so that's great. I did *not* tried to understand why the old one was missing this diffing file.