### PR TITLE
Use xeCJK when building Chinese pdf

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -82,12 +82,12 @@ SPHINXOPTS = {
     "zh-cn": [
         "-D latex_engine=xelatex",
         "-D latex_elements.inputenc=",
-        "-D latex_elements.fontenc=",
+        "-D latex_elements.fontenc='\\usepackage{xeCJK}'",
     ],
     "zh-tw": [
         "-D latex_engine=xelatex",
         "-D latex_elements.inputenc=",
-        "-D latex_elements.fontenc=",
+        "-D latex_elements.fontenc='\\usepackage{xeCJK}'",
     ],
 }
 


### PR DESCRIPTION
Currently the Chinese pdf is broken. Take tutorial.pdf for example,

![image](https://user-images.githubusercontent.com/227180/55191294-c61daf80-51dc-11e9-8e22-4a365346e316.png)

All Chinese characters are missing.

xeCJK should work, at least on my desktop, Debian testing. But I'm not sure if it works on the server.

[xeCJK](https://ctan.org/pkg/xecjk) is in texlive-xetex package, and it will use the [Fandol font](https://ctan.org/pkg/fandol), which should be in texlive-lang-chinese package.