### PR TITLE
Fix backslash escape in SPHINXOPTS

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -82,12 +82,12 @@ SPHINXOPTS = {
     "zh-cn": [
         "-D latex_engine=xelatex",
         "-D latex_elements.inputenc=",
-        "-D latex_elements.fontenc='\\usepackage{xeCJK}'",
+        r"-D latex_elements.fontenc=\\usepackage{xeCJK}",
     ],
     "zh-tw": [
         "-D latex_engine=xelatex",
         "-D latex_elements.inputenc=",
-        "-D latex_elements.fontenc='\\usepackage{xeCJK}'",
+        r"-D latex_elements.fontenc=\\usepackage{xeCJK}",
     ],
 }
 


### PR DESCRIPTION
The last commit was only tested with the latex make target, with:
`make SPHINXOPTS="-D latex_elements.fontenc='\usepackage{xeCJK}'" latex`.
It works without escaping backslash(only needs single quotas),
and we only need escape it in python code.

However the build_docs script is using autobuild-* make target.
In autobuild-dev target,

```
autobuild-dev:
	make dist SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1 -A switchers=1'
```

it calls another make target and manipulates the SPHINXOPTS environment,
so the origin single quotas no longer works.

we should call:
`make SPHINXOPTS='-D latex_elements.fontenc=\\usepackage{xeCJK}' autobuild-dev`
And in python code, we need two raw backslash.