### PR TITLE
Sentry: Split CalledProcessError in a distinct group by program.

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -117,7 +117,9 @@ def shell_out(cmd, shell=False, logfile=None):
         return output
     except subprocess.CalledProcessError as e:
         if sentry_sdk:
-            sentry_sdk.capture_exception(e)
+            with sentry_sdk.push_scope() as scope:
+                scope.fingerprint = ["{{ default }}", str(cmd)]
+                sentry_sdk.capture_exception(e)
         if logfile:
             with open(logfile, "a+") as log:
                 log.write("# " + now + "\n")


### PR DESCRIPTION
This is because currently all CalledProcessError are grouped under the same group in sentry, so `CalledProcessError Command '['chgrp', '-R', 'docs', '/srv/docs.python.org/3.7']' returned non-zero exit status 1.` can contain a `CalledProcessError Command '['make', '-C `... which is not helpful.