### PR TITLE
bpo-39514: Bump python-docs-theme to 2020.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ markupsafe==1.1.1         # via jinja2
 packaging==19.2           # via sphinx
 pygments==2.5.2           # via sphinx
 pyparsing==2.4.5          # via packaging
-python-docs-theme==2018.7
+python-docs-theme==2020.1
 pytz==2019.3              # via babel
 requests==2.22.0
 sentry-sdk==0.13.5


### PR DESCRIPTION
See https://bugs.python.org/issue39514 for more details.