### PR TITLE
Add an --outdated flag to the build_docs.py script, which sets the 'outdated' value within HTML templates.

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -19,8 +19,6 @@ ignoring the -d flag as it's given in the BRANCHES configuration.
 -d allow the docs to be built even if the branch is in
 development mode (i.e. version contains a, b or c).
 
--o builds a branch as though for an outdated version of Python.
-
 Translations are fetched from github repositories according to PEP
 545.  --languages allow select translations, use "--languages" to
 build all translations (default) or "--languages en" to skip all
@@ -429,12 +427,6 @@ def parse_args():
         help="Use make autobuild-dev instead of autobuild-stable",
     )
     parser.add_argument(
-        "-o",
-        "--outdated",
-        action="store_true",
-        help="Build documentation for an outdated release",
-    )
-    parser.add_argument(
         "-q",
         "--quick",
         action="store_true",
@@ -526,7 +518,7 @@ def main():
     venv = os.path.join(args.build_root, "venv")
     if args.branch:
         branches_to_do = [(args.branch, str(args.branch), args.devel,
-                           args.outdated)]
+                           False)]
     else:
         branches_to_do = BRANCHES
     if not args.languages:


### PR DESCRIPTION
This branch supports work on https://github.com/python/steering-council/issues/3. 

My cpython PR https://github.com/python/cpython/pull/19229/ adds a header to the top of each documentation page if the `outdated` variable is set. This branch changes the build process so that the `outdated` variable is set automatically for 2.7 releases when building the full set of documentation. The outdated variable can also be set when building a single release, using the `--outdated` command-line flag.

I've never used this script before, so I tried a number of strategies to test this change. For all of these I used specially created subdirectories to store the logs, checkouts, and HTML output, rather than using the defaults in `/srv/` and `/var/`. I also passed my own user group as `group` since I don't have a `docs` group on my machine.

1. To test the command-line arguments, I verified that this command passes `-A outdated=1` as one of the SPHINXOPTS:

```./build_docs.py --group=leonardr --log-directory=logs --www-root=output --languages en --branch=2.7 -q -o --build-root=../versions/```

Here's the relevant output (my addition is bolded):

DEBUG:Running command ['make', '-C', '/home/leonardr/programming/psf/versions/2.7/cpython-en/Doc', 'PYTHON=/home/leonardr/programming/psf/versions/venv/bin/python', 'SPHINXBUILD=/home/leonardr/programming/psf/versions/venv/bin/sphinx-build', 'BLURB=/home/leonardr/programming/psf/versions/venv/bin/blurb', 'VENVDIR=/home/leonardr/programming/psf/versions/venv', 'SPHINXOPTS=-D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc= -q **-A outdated=1**', 'SPHINXERRORHANDLING=', 'autobuild-stable-html']

2. To test the default behavior of this script -- iterating over different versions of Python -- I ran this command:

`./build_docs.py --group=leonardr --log-directory=logs --www-root=output -q -o --build-root=../versions/`

All versions of the Python 2.7 docs were built with `-A outdated=1`:

DEBUG:Running command ['make', '-C', '/home/leonardr/programming/psf/versions/2.7/cpython-en/Doc', 'PYTHON=/home/leonardr/programming/psf/versions/venv/bin/python', 'SPHINXBUILD=/home/leonardr/programming/psf/versions/venv/bin/sphinx-build', 'BLURB=/home/leonardr/programming/psf/versions/venv/bin/blurb', 'VENVDIR=/home/leonardr/programming/psf/versions/venv', 'SPHINXOPTS=-D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc= -q **-A outdated=1**', 'SPHINXERRORHANDLING=', 'autobuild-stable-html']

Docs for other versions of Python were not:

DEBUG:Running command ['make', '-C', '/home/leonardr/programming/psf/versions/3.9/cpython-zh-tw/Doc', 'PYTHON=/home/leonardr/programming/psf/versions/venv/bin/python', 'SPHINXBUILD=/home/leonardr/programming/psf/versions/venv/bin/sphinx-build', 'BLURB=/home/leonardr/programming/psf/versions/venv/bin/blurb', 'VENVDIR=/home/leonardr/programming/psf/versions/venv', 'SPHINXOPTS=-D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc=\\\\usepackage{xeCJK} -q -D locale_dirs=/home/leonardr/programming/psf/versions/3.9/locale -D language=zh_TW -D gettext_compact=0', 'SPHINXERRORHANDLING=', 'autobuild-dev-html']

3. Since this script clones the primary branch for each version of cpython, and my 2.7 change has not been merged yet, I couldn't do a complete end-to-end test. Instead I checked out  [my cpython branch](https://github.com/python/cpython/pull/19229) and then ran the `make` command generated by this script to verify that the banner shows up when `-A outdated=1` is passed in on the command line.

`make -C /home/leonardr/programming/psf/versions/2.7/cpython-en/Doc PYTHON=/home/leonardr/programming/psf/versions/venv/bin/python SPHINXBUILD=/home/leonardr/programming/psf/versions/venv/bin/sphinx-build BLURB=/home/leonardr/programming/psf/versions/venv/bin/blurb VENVDIR=/home/leonardr/programming/psf/versions/venv 'SPHINXOPTS=-D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc= -q -A outdated=1' SPHINXERRORHANDLING= autobuild-stable-html`

Here's a visual of the final result:

![image](https://user-images.githubusercontent.com/662474/79045239-0d07f880-7bd8-11ea-9edb-528b7839afd3.png)
