### PR TITLE
Show Spanish translation in production

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -140,7 +140,7 @@ XELATEX_WITH_CJK = (
 
 LANGUAGES = {
     Language("en", "en", "English", True, XELATEX_DEFAULT),
-    Language("es", "es", "Spanish", False, XELATEX_WITH_FONTSPEC),
+    Language("es", "es", "Spanish", True, XELATEX_WITH_FONTSPEC),
     Language("fr", "fr", "French", True, XELATEX_WITH_FONTSPEC),
     Language("id", "id", "Indonesian", False, XELATEX_DEFAULT),
     Language("ja", "ja", "Japanese", True, PLATEX_DEFAULT),


### PR DESCRIPTION
The Spanish translation of the documentation reached all the required translated files to be shown in the language selector under docs.python.org.

@JulienPalard Please, let me know if there is something else needed here. Thanks for all your help!