### PR TITLE
Mark 3.8 as "security-fixes"

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -100,7 +100,7 @@ VERSIONS = [
     Version("3.5", "3.5", "EOL", sphinx_version="1.8.4"),
     Version("3.6", "3.6", "security-fixes", sphinx_version="2.3.1"),
     Version("3.7", "3.7", "security-fixes", sphinx_version="2.3.1"),
-    Version("3.8", "3.8", "stable", sphinx_version="2.4.4"),
+    Version("3.8", "3.8", "security-fixes", sphinx_version="2.4.4"),
     Version("3.9", "3.9", "stable", sphinx_version="2.4.4"),
     Version("3.10", "master", "in development", sphinx_version="3.2.1"),
 ]


### PR DESCRIPTION
Per PEP 569 today's release of 3.8.10 is the last regular bugfix release.