### PR TITLE
logs_directory is now created if necessary

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -451,6 +451,7 @@ def build_one(
             maketarget,
         ]
     )
+    run(["mkdir", "-p", log_directory])
     run(["chgrp", "-R", group, log_directory])
     setup_switchers(os.path.join(checkout, "Doc", "build", "html"))
     logging.info("Build done for version: %s, language: %s", version.name, language.tag)


### PR DESCRIPTION
If logs directory does not exist build will crash. So I added a command to create this folder if necessary.