### PR TITLE
Don't show version links in EOL builds: they get out of date too fast.

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -386,23 +386,20 @@ def picker_label(version):
     return version.name
 
 
-def setup_indexsidebar(dest_path):
-    versions_li = []
-    for version in sorted(
-        VERSIONS,
-        key=lambda v: version_to_tuple(v.name),
-        reverse=True,
-    ):
-        versions_li.append(
-            '<li><a href="{}">{}</a></li>'.format(version.url, version.title)
-        )
-
-    with open(HERE / "templates" / "indexsidebar.html") as sidebar_template_file:
-        with open(dest_path, "w") as sidebar_file:
-            template = Template(sidebar_template_file.read())
-            sidebar_file.write(
-                template.safe_substitute({"VERSIONS": "\n".join(versions_li)})
+def setup_indexsidebar(dest_path, current_version):
+    with open(
+        HERE / "templates" / "indexsidebar.html", encoding="UTF-8"
+    ) as sidebar_template_file:
+        sidebar_template = jinja2.Template(sidebar_template_file.read())
+    with open(dest_path, "w", encoding="UTF-8") as sidebar_file:
+        sidebar_file.write(
+            sidebar_template.render(
+                current_version=current_version,
+                versions=sorted(
+                    VERSIONS, key=lambda v: version_to_tuple(v.name), reverse=True
+                ),
             )
+        )
 
 
 def setup_switchers(html_root):
@@ -712,7 +709,8 @@ class DocBuilder(
         setup_indexsidebar(
             os.path.join(
                 self.checkout, "Doc", "tools", "templates", "indexsidebar.html"
-            )
+            ),
+            self.version,
         )
         run(
             [

--- a/templates/indexsidebar.html
+++ b/templates/indexsidebar.html
@@ -1,11 +1,23 @@
+{#
+Beware, this file is rendered twice via Jinja2:
+- First by build_docs.py, given 'current_version' and 'versions'.
+- A 2nd time by Sphinx.
+#}
+
+{% raw %}
 <h3>{% trans %}Download{% endtrans %}</h3>
 <p><a href="{{ pathto('download') }}">{% trans %}Download these documents{% endtrans %}</a></p>
-<h3>{% trans %}Docs by version{% endtrans %}</h3>
+{% endraw %}
+{% if current_version.status != "EOL" %}
+{% raw %}<h3>{% trans %}Docs by version{% endtrans %}</h3>{% endraw %}
 <ul>
-  $VERSIONS
-  <li><a href="https://www.python.org/doc/versions/">{% trans %}All versions{% endtrans %}</a></li>
+  {% for version in versions %}
+  <li><a href="{{ version.url }}">{{ version.title }}</a></li>
+  {% endfor %}
+  {% raw %}<li><a href="https://www.python.org/doc/versions/">{% trans %}All versions{% endtrans %}</a></li>{% endraw %}
 </ul>
-
+{% endif %}
+{% raw %}
 <h3>{% trans %}Other resources{% endtrans %}</h3>
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}
@@ -15,3 +27,4 @@
   <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/Visual Talks{% endtrans %}</a></li>
   <li><a href="https://devguide.python.org/">{% trans %}Python Developer’s Guide{% endtrans %}</a></li>
 </ul>
+{% endraw %}


### PR DESCRIPTION
see: https://github.com/python/cpython/issues/91427