### PR TITLE
Remove -j4 Sphinx option as the Makefile has '-j auto'

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -200,21 +200,18 @@ VERSIONS = [
         branch="origin/main",
         status="in development",
         sphinx_version="4.5.0",
-        sphinxopts=["-j4"],
     ),
     Version(
         "3.11",
         branch="origin/3.11",
         status="pre-release",
         sphinx_version="4.5.0",
-        sphinxopts=["-j4"],
     ),
     Version(
         "3.10",
         branch="origin/3.10",
         status="stable",
         sphinx_version="3.2.1",
-        sphinxopts=["-j4"],
     ),
     Version(
         "3.9",


### PR DESCRIPTION
Follow on from https://github.com/python/cpython/pull/92733.

Backports:
* 3.11: https://github.com/python/cpython/pull/92847
* 3.10: https://github.com/python/cpython/pull/92850