### PR TITLE
Run pip freeze after installing requirements

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -786,6 +786,7 @@ class DocBuilder(
             + [self.theme]
             + self.version.requirements
         )
+        run([venv_path / "bin" / "python", "-m", "pip", "freeze", "--all"])
         self.venv = venv_path
 
     def copy_build_to_webroot(self):


### PR DESCRIPTION
It appears that the venv keeps breaking: https://github.com/python/cpython/issues/91483

I'm not sure how to best help investigate, but adding some more logging seems like it could be useful :-)