### PR TITLE
Shot in the dark fix for broken 3.10 render

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -108,7 +108,7 @@ class Version:
         if version_to_tuple(self.sphinx_version) < (4, 5):
             # see https://github.com/python/cpython/issues/91294
             reqs += ["jinja2<3.1"]
-        if version_to_tuple(self.sphinx_version) <= (3, 5, 4):
+        if version_to_tuple(self.sphinx_version) < (3, 5, 4):
             # see https://github.com/python/cpython/issues/91483
             reqs += ["docutils<=0.17.1"]
         return reqs

--- a/build_docs.py
+++ b/build_docs.py
@@ -108,7 +108,7 @@ class Version:
         if version_to_tuple(self.sphinx_version) < (4, 5):
             # see https://github.com/python/cpython/issues/91294
             reqs += ["jinja2<3.1"]
-        if version_to_tuple(self.sphinx_version) <= (3, 4, 3):
+        if version_to_tuple(self.sphinx_version) <= (3, 5, 4):
             # see https://github.com/python/cpython/issues/91483
             reqs += ["docutils<=0.17.1"]
         return reqs

--- a/build_docs.py
+++ b/build_docs.py
@@ -108,7 +108,7 @@ class Version:
         if version_to_tuple(self.sphinx_version) < (4, 5):
             # see https://github.com/python/cpython/issues/91294
             reqs += ["jinja2<3.1"]
-        if version_to_tuple(self.sphinx_version) <= (3, 2, 1):
+        if version_to_tuple(self.sphinx_version) <= (3, 4, 3):
             # see https://github.com/python/cpython/issues/91483
             reqs += ["docutils<=0.17.1"]
         return reqs


### PR DESCRIPTION
CPython 3.10 docs have been repeatedly breaking, see https://github.com/python/cpython/issues/91483

It seems likely to me that this is related to https://github.com/python/cpython/pull/93159 (although the timeline doesn't match closely)