### PR TITLE
Add Turkish to language switcher

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -253,7 +253,7 @@ LANGUAGES = {
     Language("ko", "ko", "Korean", True, XELATEX_FOR_KOREAN),
     Language("pl", "pl", "Polish", False, XELATEX_DEFAULT),
     Language("pt-br", "pt_BR", "Brazilian Portuguese", True, XELATEX_DEFAULT),
-    Language("tr", "tr", "Turkish", False, XELATEX_DEFAULT),
+    Language("tr", "tr", "Turkish", True, XELATEX_DEFAULT),
     Language("uk", "uk", "Ukrainian", False, XELATEX_DEFAULT),
     Language("zh-cn", "zh_CN", "Simplified Chinese", True, XELATEX_WITH_CJK),
     Language("zh-tw", "zh_TW", "Traditional Chinese", True, XELATEX_WITH_CJK),


### PR DESCRIPTION
We have completed the translation of all the required files as specified in [PEP 545](https://peps.python.org/pep-0545/#add-translation-to-the-language-switcher).

Translation repo: https://github.com/python/python-docs-tr