### PR TITLE
Fix japanese doc build error

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -259,7 +259,7 @@ LANGUAGES = {
     Language("fr", "fr", "French", True, XELATEX_WITH_FONTSPEC),
     Language("id", "id", "Indonesian", False, XELATEX_DEFAULT),
     Language("it", "it", "Italian", False, XELATEX_DEFAULT),
-    Language("ja", "ja", "Japanese", True, PLATEX_DEFAULT, html_only=True),  # See https://github.com/python/python-docs-ja/issues/35
+    Language("ja", "ja", "Japanese", True, PLATEX_DEFAULT),
     Language("ko", "ko", "Korean", True, XELATEX_FOR_KOREAN),
     Language("pl", "pl", "Polish", False, XELATEX_DEFAULT),
     Language("pt-br", "pt_BR", "Brazilian Portuguese", True, XELATEX_DEFAULT),

--- a/build_docs.py
+++ b/build_docs.py
@@ -229,6 +229,8 @@ PLATEX_DEFAULT = (
     "-D latex_engine=platex",
     "-D latex_elements.inputenc=",
     "-D latex_elements.fontenc=",
+    # See https://github.com/python/python-docs-ja/issues/35
+    r"-D latex_elements.preamble=\\usepackage{kotex}",
 )
 
 XELATEX_WITH_FONTSPEC = (


### PR DESCRIPTION
Changes aims to fix the problem on building Japanese PDF doc reported the following issue. 

https://github.com/python/python-docs-ja/issues/35

I've confirmed the the error disappeared in the build of Python 3.11 documentation on Docker container based on Ubuntu 22.04. 

Please note that this fix is a workaround to avoid confronting error rather than the one to fix essential problem. Given that the `U+C4CF` is Korean character, I added an option to use Korean latex package. It is weird that Korean latex package is required to build Japanese documentation. But it appears that it somehow works. 

Any suggestions are welcome. Thanks in advance!