### PR TITLE
Revert "Fix japanese doc build error"

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -229,8 +229,6 @@ PLATEX_DEFAULT = (
     "-D latex_engine=platex",
     "-D latex_elements.inputenc=",
     "-D latex_elements.fontenc=",
-    # See https://github.com/python/python-docs-ja/issues/35
-    r"-D latex_elements.preamble=\\usepackage{kotex}",
 )
 
 XELATEX_WITH_FONTSPEC = (
@@ -259,7 +257,7 @@ LANGUAGES = {
     Language("fr", "fr", "French", True, XELATEX_WITH_FONTSPEC),
     Language("id", "id", "Indonesian", False, XELATEX_DEFAULT),
     Language("it", "it", "Italian", False, XELATEX_DEFAULT),
-    Language("ja", "ja", "Japanese", True, PLATEX_DEFAULT),
+    Language("ja", "ja", "Japanese", True, PLATEX_DEFAULT, html_only=True),  # See https://github.com/python/python-docs-ja/issues/35
     Language("ko", "ko", "Korean", True, XELATEX_FOR_KOREAN),
     Language("pl", "pl", "Polish", False, XELATEX_DEFAULT),
     Language("pt-br", "pt_BR", "Brazilian Portuguese", True, XELATEX_DEFAULT),


### PR DESCRIPTION
Reverts python/docsbuild-scripts#144

It did not worked, see https://github.com/python/docsbuild-scripts/pull/144