### PR TITLE
Provide allowed choices for branch CLI argument

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -23,7 +23,7 @@ from argparse import ArgumentParser
 from contextlib import suppress
 from dataclasses import dataclass
 import filecmp
-from itertools import product
+from itertools import chain, product
 import json
 import logging
 import logging.handlers
@@ -590,7 +590,8 @@ def parse_args():
     parser.add_argument(
         "-b",
         "--branch",
-        metavar="3.6",
+        choices=dict.fromkeys(chain(*((v.branch_or_tag, v.name) for v in VERSIONS))),
+        metavar=Version.current_dev().name,
         help="Version to build (defaults to all maintained branches).",
     )
     parser.add_argument(


### PR DESCRIPTION
Provide set of allowed choices for branch CLI argument. Set metavar to most recent version.

Previously providing not supported branch name would effect with executing the script for empty list of versions (false negative). By providing choices we validate provided argument (disallowed value will exit the script with exit code `2`).

Example:
```
% python build_docs.py … --branch 3.121
usage: build_docs.py [-h] [-q] [-b 3.12] [-r BUILD_ROOT] [-w WWW_ROOT] [--skip-cache-invalidation] [--group GROUP] [--log-directory LOG_DIRECTORY] [--languages [fr ...]] [--version] [--theme THEME]
build_docs.py: error: argument -b/--branch: invalid choice: '3.121' (choose from 'origin/main', 'origin/3.11', 'origin/3.10', 'origin/3.9', 'origin/3.8', 'origin/3.7', '3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6', '3.5', '2.7')
```

This PR uses own `sorted` key function instead of using `natsort` (please see https://github.com/python/docsbuild-scripts/pull/152 for alternative). (I cannot decide between simplicity and introducing a new dependency.)