### PR TITLE
Provide set of allowed choices for branch CLI argument (natsort)

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -23,7 +23,7 @@ from argparse import ArgumentParser
 from contextlib import suppress
 from dataclasses import dataclass
 import filecmp
-from itertools import product
+from itertools import product, chain
 import json
 import logging
 import logging.handlers
@@ -45,6 +45,7 @@ from textwrap import indent
 import zc.lockfile
 import jinja2
 import requests
+from natsort import natsorted
 
 HERE = Path(__file__).resolve().parent
 
@@ -590,7 +591,11 @@ def parse_args():
     parser.add_argument(
         "-b",
         "--branch",
-        metavar="3.6",
+        choices=natsorted(
+            set(chain.from_iterable((v.name, v.branch_or_tag) for v in VERSIONS)),
+            reverse=True,
+        ),
+        metavar=VERSIONS[0].name,
         help="Version to build (defaults to all maintained branches).",
     )
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jinja2
 requests
 sentry-sdk
 zc.lockfile
+natsort


### PR DESCRIPTION
Provide set of allowed choices for branch CLI argument. Set metavar to most recent version.

Previously providing not supported branch name would effect with executing the script for empty list of versions (false negative). By providing choices we validate provided argument.

Example:
```
% python build_docs.py … --branch 3.121
usage: build_docs.py [-h] [-q] [-b 3.12] [-r BUILD_ROOT] [-w WWW_ROOT] [--skip-cache-invalidation] [--group GROUP] [--log-directory LOG_DIRECTORY] [--languages [fr ...]] [--version] [--theme THEME]
build_docs.py: error: argument -b/--branch: invalid choice: '3.121' (choose from 'origin/main', 'origin/3.11', 'origin/3.10', 'origin/3.9', 'origin/3.8', 'origin/3.7', '3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6', '3.5', '2.7')
```

This PR uses natsort instead of providing own key function to `sorted` (please see #151 for alternative). (I cannot decide between simplicity and introducing a new dependency.)