### PR TITLE
'pip install --upgrade' to automatically deploy newer requirements

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -835,7 +835,7 @@ class DocBuilder:
         venv_path = self.build_root / ("venv-" + self.version.name)
         run([sys.executable, "-m", "venv", venv_path])
         run(
-            [venv_path / "bin" / "python", "-m", "pip", "install"]
+            [venv_path / "bin" / "python", "-m", "pip", "install", "--upgrade"]
             + [self.theme]
             + self.version.requirements,
             cwd=self.checkout / "Doc",


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/134.

So we don't need someone to ssh in to the server and manually delete the venv.