### PR TITLE
Update PEP Index URL to canonical form

### DIFF
--- a/templates/indexsidebar.html
+++ b/templates/indexsidebar.html
@@ -21,7 +21,7 @@ Beware, this file is rendered twice via Jinja2:
 <h3>{% trans %}Other resources{% endtrans %}</h3>
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}
-  <li><a href="https://www.python.org/dev/peps/">{% trans %}PEP Index{% endtrans %}</a></li>
+  <li><a href="https://peps.python.org/">{% trans %}PEP Index{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/BeginnersGuide">{% trans %}Beginner's Guide{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/PythonBooks">{% trans %}Book List{% endtrans %}</a></li>
   <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/Visual Talks{% endtrans %}</a></li>

--- a/templates/indexsidebar.html
+++ b/templates/indexsidebar.html
@@ -21,7 +21,7 @@ Beware, this file is rendered twice via Jinja2:
 <h3>{% trans %}Other resources{% endtrans %}</h3>
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}
-  <li><a href="https://peps.python.org/">{% trans %}PEP Index{% endtrans %}</a></li>
+  <li><a href="https://peps.python.org">{% trans %}PEP Index{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/BeginnersGuide">{% trans %}Beginner's Guide{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/PythonBooks">{% trans %}Book List{% endtrans %}</a></li>
   <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/Visual Talks{% endtrans %}</a></li>


### PR DESCRIPTION
Update to use the canonical form of https://peps.python.org/

Matches https://github.com/python/cpython/blob/main/Doc/tools/templates/indexsidebar.html, already updated in https://github.com/python/cpython/pull/32124.