### PR TITLE
Clone per version (branch) to allow differential builds

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -30,6 +30,7 @@ import logging
 import logging.handlers
 from functools import partial, total_ordering
 from os import readlink
+import platform
 import re
 import shlex
 import shutil
@@ -745,13 +746,14 @@ class DocBuilder:
         sphinxbuild = self.venv / "bin" / "sphinx-build"
         blurb = self.venv / "bin" / "blurb"
         # Disable cpython switchers, we handle them now:
+
+        def is_mac():
+            return platform.system() == 'Darwin'
+
         run(
-            [
-                "sed",
-                "-i",
-                "s/ *-A switchers=1//",
-                self.checkout / "Doc" / "Makefile",
-            ]
+            ["sed", "-i"]
+            + ([""] if is_mac() else [])
+            + ["s/ *-A switchers=1//", self.checkout / "Doc" / "Makefile"]
         )
         self.version.setup_indexsidebar(
             self.versions,

--- a/build_docs.py
+++ b/build_docs.py
@@ -1115,7 +1115,7 @@ def build_docs(args) -> bool:
     cpython_repo = partial(Repository, "https://github.com/python/cpython.git")
     while todo:
         version, language = todo.pop()
-        cpython_branch_repo = cpython_repo(args.build_root / "cpython_branches" / version)
+        cpython_branch_repo = cpython_repo(args.build_root / "cpython_branches" / version.name)
         cpython_branch_repo.update()
         logging.root.handlers[0].setFormatter(
             logging.Formatter(

--- a/build_docs.py
+++ b/build_docs.py
@@ -977,7 +977,7 @@ class DocBuilder:
         state_file.write_text(tomlkit.dumps(states), encoding="UTF-8")
 
 
-def symlink(www_root: Path, language: Language, directory: str, name: str, group: str):
+def symlink(www_root: Path, language: Language, directory: str, name: str, group: str, skip_cache_invalidation: bool):
     """Used by major_symlinks and dev_symlink to maintain symlinks."""
     if language.tag == "en":  # english is rooted on /, no /en/
         path = www_root
@@ -993,11 +993,12 @@ def symlink(www_root: Path, language: Language, directory: str, name: str, group
         link.unlink()
     link.symlink_to(directory)
     run(["chown", "-h", ":" + group, str(link)])
-    purge_path(www_root, link)
+    if not skip_cache_invalidation:
+        purge_path(www_root, link)
 
 
 def major_symlinks(
-    www_root: Path, group, versions: Iterable[Version], languages: Iterable[Language]
+    www_root: Path, group, versions: Iterable[Version], languages: Iterable[Language], skip_cache_invalidation: bool
 ):
     """Maintains the /2/ and /3/ symlinks for each languages.
 
@@ -1008,11 +1009,11 @@ def major_symlinks(
     """
     current_stable = Version.current_stable(versions).name
     for language in languages:
-        symlink(www_root, language, current_stable, "3", group)
-        symlink(www_root, language, "2.7", "2", group)
+        symlink(www_root, language, current_stable, "3", group, skip_cache_invalidation)
+        symlink(www_root, language, "2.7", "2", group, skip_cache_invalidation)
 
 
-def dev_symlink(www_root: Path, group, versions, languages):
+def dev_symlink(www_root: Path, group, versions, languages, skip_cache_invalidation: bool):
     """Maintains the /dev/ symlinks for each languages.
 
     Like:
@@ -1022,7 +1023,7 @@ def dev_symlink(www_root: Path, group, versions, languages):
     """
     current_dev = Version.current_dev(versions).name
     for language in languages:
-        symlink(www_root, language, current_dev, "dev", group)
+        symlink(www_root, language, current_dev, "dev", group, skip_cache_invalidation)
 
 
 def purge(*paths):
@@ -1138,8 +1139,8 @@ def build_docs(args) -> bool:
     build_robots_txt(
         versions, languages, args.www_root, args.group, args.skip_cache_invalidation
     )
-    major_symlinks(args.www_root, args.group, versions, languages)
-    dev_symlink(args.www_root, args.group, versions, languages)
+    major_symlinks(args.www_root, args.group, versions, languages, args.skip_cache_invalidation)
+    dev_symlink(args.www_root, args.group, versions, languages, args.skip_cache_invalidation)
     proofread_canonicals(args.www_root, args.skip_cache_invalidation)
 
     return all_built_successfully


### PR DESCRIPTION
Less differences on git updates should speed up the Sphinx builds basing on shared filesystem directory.

### Testing strategy
Config simplified: two versions, two languages.

* run from main "first run", note the time
* run from main "second run", note the time
* run from branch "first run", note the time
* run from branch "second run", note the time

`cpython` / `cpython_branches` directories will be used so no clean-up is required between the runs.

Command: `time python build_docs.py --build-root /tmp/docsbuild-test/build --www-root /tmp/docsbuild-test/www --skip-cache-invalidation --log-directory /tmp/docsbuild-test/logs --quick --group everyone`.

Original script modified to always return `should_rebuild() == True` to allow testing the Sphinx part.