### PR TITLE
Migrate sentry from 1.x to 2.x

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -1124,9 +1124,9 @@ def build_docs(args) -> bool:
             )
         )
         if sentry_sdk:
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_tag("version", version.name)
-                scope.set_tag("language", language.tag)
+            scope = sentry_sdk.get_isolation_scope()
+            scope.set_tag("version", version.name)
+            scope.set_tag("language", language.tag)
         builder = DocBuilder(
             version, versions, language, languages, cpython_repo, **vars(args)
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2
 requests
-sentry-sdk
+sentry-sdk>=2
 tomlkit
 zc.lockfile


### PR DESCRIPTION
This resolves the deprecation warning reported in #181.