### PR TITLE
Add ``--select-output``

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /www/
 # temporary lock file created while building the docs
 build_docs.lock
+build_docs_archives.lock
+build_docs_html.lock
 
 
 # Created by https://www.gitignore.io/api/python

--- a/build_docs.py
+++ b/build_docs.py
@@ -630,7 +630,7 @@ class DocBuilder:
     @property
     def checkout(self) -> Path:
         """Path to CPython git clone."""
-        return self.build_root / "cpython"
+        return self.build_root / _checkout_name(self.select_output)
 
     def clone_translation(self):
         self.translation_repo.update()
@@ -1129,7 +1129,8 @@ def build_docs(args) -> bool:
     del args.languages
     all_built_successfully = True
     cpython_repo = Repository(
-        "https://github.com/python/cpython.git", args.build_root / "cpython"
+        "https://github.com/python/cpython.git",
+        args.build_root / _checkout_name(args.select_output),
     )
     while todo:
         version, language = todo.pop()
@@ -1182,6 +1183,12 @@ def build_docs(args) -> bool:
     logging.info("Full build done (%s).", format_seconds(perf_counter() - start_time))
 
     return all_built_successfully
+
+
+def _checkout_name(select_output: str | None) -> str:
+    if select_output is not None:
+        return f"cpython-{select_output}"
+    return "cpython"
 
 
 def main():

--- a/build_docs.py
+++ b/build_docs.py
@@ -22,7 +22,7 @@ Modified by Julien Palard to build translations.
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from contextlib import suppress, contextmanager
 from dataclasses import dataclass
@@ -1204,7 +1204,7 @@ def main():
         build_docs_with_lock(args, "build_docs_html.lock")
 
 
-def build_docs_with_lock(args, lockfile_name):
+def build_docs_with_lock(args: Namespace, lockfile_name: str) -> int:
     try:
         lock = zc.lockfile.LockFile(HERE / lockfile_name)
     except zc.lockfile.LockError:


### PR DESCRIPTION
Towards https://github.com/python/docs-community/issues/131

If either of the options to ``--select-output`` is given, a different lockfile is generated and checked. We also invert some options because in the future both HTML and non-HTML builds will require archiving their files, so we only skip archiving when ``--quick`` is passed.

If ``--select-output`` is missing, the current behaviour is retained, so merging this should have no impact on the current process.

I believe that running ``rsync -a --delete-delay --filter P archives/ <build path> <target path>`` is harmless on quick builds, so we remove an if/else here.
