### PR TITLE
Log updates to ``state.toml``

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -949,9 +949,9 @@ class DocBuilder:
         states[key] = state
         state_file.write_text(tomlkit.dumps(states), encoding="UTF-8")
 
-        tbl = tomlkit.inline_table()
-        tbl |= state
-        logging.info("Saved new rebuild state for %s: %s", key, tbl.as_string())
+        table = tomlkit.inline_table()
+        table |= state
+        logging.info("Saved new rebuild state for %s: %s", key, table.as_string())
 
 
 def symlink(


### PR DESCRIPTION
* Round duration seconds to the nearest integer
* Change `last_build` to the start time instead of the end time
* Don't include microseconds in ``last_build_start``

This allows using the useful data captured in `state.toml` for longitudinal analysis via the log files. It would simplify much of the code in ``check_times.py`` (should we include ``trigger`` in `state.toml`?)

A