### PR TITLE
Skip non-HTML builds for HTML-only languages

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -640,6 +640,9 @@ class DocBuilder:
         start_timestamp = dt.now(tz=timezone.utc).replace(microsecond=0)
         logging.info("Running.")
         try:
+            if self.language.html_only and not self.includes_html:
+                logging.info("Skipping non-HTML build (language is HTML-only).")
+                return True
             self.cpython_repo.switch(self.version.branch_or_tag)
             if self.language.tag != "en":
                 self.clone_translation()


### PR DESCRIPTION
Resolves https://github.com/python/docsbuild-scripts/pull/205#issuecomment-2385243164 cc @hugovk 

Currently, the non-HTML build for HTML-only languages runs the ``autobuild-dev-html`` target, because the `html_only` property checks `self.language.html_only`.

A