### PR TITLE
Rebuild on changes to Misc/NEWS.d/

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -929,7 +929,7 @@ class DocBuilder:
             diff = self.cpython_repo.run(
                 "diff", "--name-only", state["cpython_sha"], cpython_sha
             ).stdout
-            if "Doc/" in diff:
+            if "Doc/" in diff or "Misc/NEWS.d/" in diff:
                 logging.info(
                     "Should rebuild: Doc/ has changed (from %s to %s)",
                     state["cpython_sha"],


### PR DESCRIPTION
I wondered why https://docs.python.org/3.13/ still said "3.13.0rc2" -- the most recent commits pushed created `Misc/NEWS.d/3.13.0rc3.rst` from `Misc/NEWS.d/next/`, but had no changes to `Doc/`, so no rebuild has been triggered. This PR fixes this (edge case).

A