### PR TITLE
Run `sphinx-build` with the default verbosity level

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -704,7 +704,6 @@ class DocBuilder:
         logging.info("Build start.")
         start_time = perf_counter()
         sphinxopts = list(self.language.sphinxopts)
-        sphinxopts.extend(["-q"])
         if self.language.tag != "en":
             locale_dirs = self.build_root / self.version.name / "locale"
             sphinxopts.extend(


### PR DESCRIPTION
A proposal, as this would add to the logs, but would also let us see which steps are taking more time in sphinx.

Quiet mode was originally added in 8d82617d78e25448b379003a811629b7329209b1.

A