### PR TITLE
Add 3.8 to robots.txt

### DIFF
--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -23,3 +23,4 @@ Disallow: /3.4/
 Disallow: /3.5/
 Disallow: /3.6/
 Disallow: /3.7/
+Disallow: /3.8/


### PR DESCRIPTION
Follows #165. Python 3.8 has ceased to be.

A