### PR TITLE
Simplify `Version.requirements`

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -110,10 +110,8 @@ class Version:
         """
         if self.name == "3.5":
             return ["jieba", "blurb", "sphinx==1.8.4", "jinja2<3.1", "docutils<=0.17.1"]
-        if self.name in ("3.7", "3.6", "2.7"):
+        if self.name in {"3.7", "3.6", "2.7"}:
             return ["jieba", "blurb", "sphinx==2.3.1", "jinja2<3.1", "docutils<=0.17.1"]
-        if self.name == ("3.8", "3.9"):
-            return ["jieba", "blurb", "sphinx==2.4.4", "jinja2<3.1", "docutils<=0.17.1"]
 
         return [
             "jieba",  # To improve zh search.


### PR DESCRIPTION
`self.name == ("3.8", "3.9")` is never true, as the test should be `in`. However it is also unneeded, as both versions have a requirements.txt file with identical versions:

* https://github.com/python/cpython/blob/3.8/Doc/requirements.txt
* https://github.com/python/cpython/blob/3.9/Doc/requirements.txt

A