### PR TITLE
Always purge symlinks

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -996,10 +996,9 @@ def symlink(
     if not directory_path.exists():
         return  # No touching link, dest doc not built yet.
 
-    link_exists = link.exists()
-    if not link_exists or readlink(link) != directory:
+    if not link.exists() or readlink(link) != directory:
         # Link does not exist or points to the wrong target.
-        if link_exists:
+        if link.exists():
             link.unlink()
         link.symlink_to(directory)
         run(["chown", "-h", f":{group}", str(link)])

--- a/build_docs.py
+++ b/build_docs.py
@@ -995,12 +995,14 @@ def symlink(
     directory_path = path / directory
     if not directory_path.exists():
         return  # No touching link, dest doc not built yet.
-    if link.exists() and readlink(link) == directory:
-        return  # Link is already pointing to right doc.
-    if link.exists():
-        link.unlink()
-    link.symlink_to(directory)
-    run(["chown", "-h", ":" + group, str(link)])
+
+    link_exists = link.exists()
+    if not link_exists or readlink(link) != directory:
+        # Link does not exist or points to the wrong target.
+        if link_exists:
+            link.unlink()
+        link.symlink_to(directory)
+        run(["chown", "-h", f":{group}", str(link)])
     if not skip_cache_invalidation:
         surrogate_key = f"{language.tag}/{name}"
         purge_surrogate_key(http, surrogate_key)


### PR DESCRIPTION
Currently, `/3/` is not purged when `/3.13/` updates (and the same for `/dev/`). This is a quick fix, a better solution would either to use rewrite rules in Nginx or to check if the symlink target has been rebuilt.

A