### PR TITLE
Allow passing multiple branches to build via CLI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_also =
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,10 @@ jobs:
       - name: Tox tests
         run: |
           uvx --with tox-uv tox -e py
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5.1.1
+        with:
+          flags: ${{ matrix.os }}
+          name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           uvx --with tox-uv tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5.1.1
+        uses: codecov/codecov-action@v5
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 ./build_docs.py --quick --build-root ./build_root --www-root ./www --log
 ```
 
 If you don't need to build all translations of all branches, add
-`--language en --branch main`.
+`--language en --branches main`.
 
 
 ## Check current version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# docsbuild-scripts
+
+[![GitHub Actions status](https://github.com/python/docsbuild-scripts/actions/workflows/test.yml/badge.svg)](https://github.com/python/docsbuild-scripts/actions/workflows/test.yml)
+[![Codecov](https://codecov.io/gh/python/docsbuild-scripts/branch/main/graph/badge.svg)](https://codecov.io/gh/python/docsbuild-scripts)
+
 This repository contains scripts for automatically building the Python
 documentation on [docs.python.org](https://docs.python.org).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 ./build_docs.py --quick --build-root ./build_root --www-root ./www --log
 ```
 
 If you don't need to build all translations of all branches, add
-`--language en --branches main`.
+`--languages en --branches main`.
 
 
 ## Check current version

--- a/build_docs.py
+++ b/build_docs.py
@@ -936,13 +936,6 @@ def parse_args():
         help="Run a quick build (only HTML files).",
     )
     parser.add_argument(
-        "--branch",
-        nargs="*",
-        metavar="3.12",
-        deprecated=True,
-        help="Deprecated; use --branches instead.",
-    )
-    parser.add_argument(
         "-b",
         "--branches",
         nargs="*",
@@ -981,7 +974,6 @@ def parse_args():
     )
     parser.add_argument(
         "--languages",
-        "--language",
         nargs="*",
         help="Language translation, as a PEP 545 language tag like"
         " 'fr' or 'pt-br'. "

--- a/build_docs.py
+++ b/build_docs.py
@@ -86,7 +86,7 @@ class Versions:
         )
         return cls(versions)
 
-    def filter(self, branches: list[str] = None) -> Sequence[Version]:
+    def filter(self, branches: Sequence[str] = ()) -> Sequence[Version]:
         """Filter the given versions.
 
         If *branches* is given, only *versions* matching *branches* are returned.
@@ -95,8 +95,9 @@ class Versions:
         security-fixes branches).
         """
         if branches:
+            branches = frozenset(branches)
             return [
-                v for v in self if v.name in branches or v.branch_or_tag in branches
+                v for v in self if {v.name, v.branch_or_tag} & branches
             ]
         return [v for v in self if v.status not in {"EOL", "security-fixes"}]
 
@@ -996,9 +997,6 @@ def parse_args():
         version_info()
         sys.exit(0)
     del args.version
-    if args.branch and not args.branches:
-        args.branches = args.branch
-        del args.branch
     if args.log_directory:
         args.log_directory = args.log_directory.resolve()
     if args.build_root:

--- a/build_docs.py
+++ b/build_docs.py
@@ -936,8 +936,14 @@ def parse_args():
         help="Run a quick build (only HTML files).",
     )
     parser.add_argument(
+        "--branch",
+        nargs="*",
+        metavar="3.12",
+        deprecated=True,
+        help="Deprecated; use --branches instead.",
+    )
+    parser.add_argument(
         "-b",
-        "--branch",  # Deprecated
         "--branches",
         nargs="*",
         metavar="3.12",
@@ -998,6 +1004,9 @@ def parse_args():
         version_info()
         sys.exit(0)
     del args.version
+    if args.branch and not args.branches:
+        args.branches = args.branch
+        del args.branch
     if args.log_directory:
         args.log_directory = args.log_directory.resolve()
     if args.build_root:
@@ -1049,10 +1058,10 @@ def build_docs(args: argparse.Namespace) -> bool:
     # This runs languages in config.toml order and versions newest first.
     todo = [
         (version, language)
-        for version in versions.filter(args.branch)
+        for version in versions.filter(args.branches)
         for language in reversed(languages.filter(args.languages))
     ]
-    del args.branch
+    del args.branches
     del args.languages
 
     build_succeeded = set()

--- a/build_docs.py
+++ b/build_docs.py
@@ -86,16 +86,18 @@ class Versions:
         )
         return cls(versions)
 
-    def filter(self, branch: str = "") -> Sequence[Version]:
+    def filter(self, branches: list[str] = None) -> Sequence[Version]:
         """Filter the given versions.
 
-        If *branch* is given, only *versions* matching *branch* are returned.
+        If *branches* is given, only *versions* matching *branches* are returned.
 
         Else all live versions are returned (this means no EOL and no
         security-fixes branches).
         """
-        if branch:
-            return [v for v in self if branch in (v.name, v.branch_or_tag)]
+        if branches:
+            return [
+                v for v in self if v.name in branches or v.branch_or_tag in branches
+            ]
         return [v for v in self if v.status not in {"EOL", "security-fixes"}]
 
     @property
@@ -935,9 +937,11 @@ def parse_args():
     )
     parser.add_argument(
         "-b",
-        "--branch",
+        "--branch",  # Deprecated
+        "--branches",
+        nargs="*",
         metavar="3.12",
-        help="Version to build (defaults to all maintained branches).",
+        help="Versions to build (defaults to all maintained branches).",
     )
     parser.add_argument(
         "-r",

--- a/build_docs.py
+++ b/build_docs.py
@@ -96,9 +96,7 @@ class Versions:
         """
         if branches:
             branches = frozenset(branches)
-            return [
-                v for v in self if {v.name, v.branch_or_tag} & branches
-            ]
+            return [v for v in self if {v.name, v.branch_or_tag} & branches]
         return [v for v in self if v.status not in {"EOL", "security-fixes"}]
 
     @property

--- a/tests/test_build_docs_version.py
+++ b/tests/test_build_docs_version.py
@@ -1,0 +1,19 @@
+from build_docs import Version
+
+
+def test_filter() -> None:
+    # Arrange
+    versions = [
+        Version("3.14", status="feature"),
+        Version("3.13", status="bugfix"),
+        Version("3.12", status="bugfix"),
+        Version("3.11", status="security"),
+        Version("3.10", status="security"),
+        Version("3.9", status="security"),
+    ]
+
+    # Act
+    filtered = Version.filter(versions, "3.13")
+
+    # Assert
+    assert filtered == [Version("3.13", status="security")]

--- a/tests/test_build_docs_versions.py
+++ b/tests/test_build_docs_versions.py
@@ -3,17 +3,17 @@ from build_docs import Versions, Version
 
 def test_filter_default() -> None:
     # Arrange
-    versions = [
+    versions = Versions([
         Version("3.14", status="feature"),
         Version("3.13", status="bugfix"),
         Version("3.12", status="bugfix"),
         Version("3.11", status="security"),
         Version("3.10", status="security"),
         Version("3.9", status="security"),
-    ]
+    ])
 
     # Act
-    filtered = Version.filter(versions)
+    filtered = versions.filter()
 
     # Assert
     assert filtered == [

--- a/tests/test_build_docs_versions.py
+++ b/tests/test_build_docs_versions.py
@@ -35,7 +35,28 @@ def test_filter_one() -> None:
     ])
 
     # Act
-    filtered = versions.filter("3.13")
+    filtered = versions.filter(["3.13"])
 
     # Assert
     assert filtered == [Version("3.13", status="security")]
+
+
+def test_filter_multiple() -> None:
+    # Arrange
+    versions = Versions([
+        Version("3.14", status="feature"),
+        Version("3.13", status="bugfix"),
+        Version("3.12", status="bugfix"),
+        Version("3.11", status="security"),
+        Version("3.10", status="security"),
+        Version("3.9", status="security"),
+    ])
+
+    # Act
+    filtered = versions.filter(["3.13", "3.14"])
+
+    # Assert
+    assert filtered == [
+        Version("3.14", status="feature"),
+        Version("3.13", status="security"),
+    ]

--- a/tests/test_build_docs_versions.py
+++ b/tests/test_build_docs_versions.py
@@ -1,19 +1,19 @@
-from build_docs import Version
+from build_docs import Versions, Version
 
 
 def test_filter() -> None:
     # Arrange
-    versions = [
+    versions = Versions([
         Version("3.14", status="feature"),
         Version("3.13", status="bugfix"),
         Version("3.12", status="bugfix"),
         Version("3.11", status="security"),
         Version("3.10", status="security"),
         Version("3.9", status="security"),
-    ]
+    ])
 
     # Act
-    filtered = Version.filter(versions, "3.13")
+    filtered = versions.filter("3.13")
 
     # Assert
     assert filtered == [Version("3.13", status="security")]

--- a/tests/test_build_docs_versions.py
+++ b/tests/test_build_docs_versions.py
@@ -1,7 +1,29 @@
 from build_docs import Versions, Version
 
 
-def test_filter() -> None:
+def test_filter_default() -> None:
+    # Arrange
+    versions = [
+        Version("3.14", status="feature"),
+        Version("3.13", status="bugfix"),
+        Version("3.12", status="bugfix"),
+        Version("3.11", status="security"),
+        Version("3.10", status="security"),
+        Version("3.9", status="security"),
+    ]
+
+    # Act
+    filtered = Version.filter(versions)
+
+    # Assert
+    assert filtered == [
+        Version("3.14", status="feature"),
+        Version("3.13", status="bugfix"),
+        Version("3.12", status="bugfix"),
+    ]
+
+
+def test_filter_one() -> None:
     # Arrange
     versions = Versions([
         Version("3.14", status="feature"),

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,19 @@ skip_install = true
 deps =
     -r requirements.txt
     pytest
+    pytest-cov
+pass_env =
+    FORCE_COLOR
+set_env =
+    COVERAGE_CORE = sysmon
 commands =
-    {envpython} -m pytest {posargs}
+    {envpython} -m pytest \
+      --cov . \
+      --cov tests \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
+      {posargs}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
A full set of Python 3.9-3.13 security+bugfix releases were made last week:

https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214

The bugfix branches (3.12 and 3.13) are automatically built on cron.

The security branches (3.9-3.11) need manual rebuilds. We also have the final 3.8 to manually run. It's taken 16 and 13 hours for a full build of the first two so far (3.11 and 3.10; see https://github.com/python/docsbuild-scripts/issues/216).

We will certainly have big omnibus security releases in the future and instead of having to run each one separately:

```sh
/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --branch 3.11
/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --branch 3.10
/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --branch 3.9
/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --branch 3.8
```

It would be useful to pass all branch versions, in a similar way we can with `--languages`:

```sh
/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --branch 3.11 3.10 3.9 3.8
```

This PR does that.

I added unit tests for the `Version.filter` method I changed, along with coverage. We can use coverage to guide adding more tests in the future.

---

I also added `--branches` as a new name for this argument and kept the old `--branch` so as not to break any other scripts, but we could change it later.

We could also make it's use more explicitly deprecated, like print a warning if `--branch` is used? Maybe it's safe to rename it right away?
