### PR TITLE
Identify the language correctly for older versions

### DIFF
--- a/templates/switchers.js
+++ b/templates/switchers.js
@@ -6,7 +6,13 @@ const _is_file_uri = (uri) => uri.startsWith("file:/");
 const _IS_LOCAL = _is_file_uri(window.location.href);
 const _CURRENT_RELEASE = DOCUMENTATION_OPTIONS.VERSION || "";
 const _CURRENT_VERSION = _CURRENT_RELEASE.split(".", 2).join(".");
-const _CURRENT_LANGUAGE = DOCUMENTATION_OPTIONS.LANGUAGE?.toLowerCase() || "en";
+const _CURRENT_LANGUAGE = (() => {
+  const _LANGUAGE = DOCUMENTATION_OPTIONS.LANGUAGE?.toLowerCase() || "en";
+  // Python 2.7 and 3.5--3.10 use ``LANGUAGE: 'None'`` for English
+  // in ``documentation_options.js``.
+  if (_LANGUAGE === "none") return "en";
+  return _LANGUAGE;
+})();
 const _CURRENT_PREFIX = (() => {
   if (_IS_LOCAL) return null;
   // Sphinx 7.2+ defines the content root data attribute in the HTML element.


### PR DESCRIPTION
Closes https://github.com/python/docsbuild-scripts/issues/241

See 

https://docs.python.org/3.10/_static/documentation_options.js

```js
var DOCUMENTATION_OPTIONS = {
    URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
    VERSION: '3.10.16',
    LANGUAGE: 'None',
    COLLAPSE_INDEX: false,
    BUILDER: 'html',
    FILE_SUFFIX: '.html',
    LINK_SUFFIX: '.html',
    HAS_SOURCE: true,
    SOURCELINK_SUFFIX: '.txt',
    NAVIGATION_WITH_KEYS: false
};
```

vs 

https://docs.python.org/3.11/_static/documentation_options.js

```js
const DOCUMENTATION_OPTIONS = {
    VERSION: '3.11.11',
    LANGUAGE: 'en',
    COLLAPSE_INDEX: false,
    BUILDER: 'html',
    FILE_SUFFIX: '.html',
    LINK_SUFFIX: '.html',
    HAS_SOURCE: true,
    SOURCELINK_SUFFIX: '.txt',
    NAVIGATION_WITH_KEYS: false,
    SHOW_SEARCH_SUMMARY: true,
    ENABLE_SEARCH_SHORTCUTS: true,
};
```

A