### PR TITLE
Include languages' translated names in the switcher

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -196,6 +196,7 @@ class Version:
 class Language:
     iso639_tag: str
     name: str
+    translated_name: str
     in_prod: bool
     sphinxopts: tuple
     html_only: bool = False
@@ -203,6 +204,12 @@ class Language:
     @property
     def tag(self):
         return self.iso639_tag.replace("_", "-").lower()
+
+    @property
+    def switcher_label(self):
+        if self.translated_name:
+            return f"{self.name} | {self.translated_name}"
+        return self.name
 
     @staticmethod
     def filter(languages, language_tags=None):
@@ -388,7 +395,7 @@ def setup_switchers(
     - Cross-link various languages in a language switcher
     - Cross-link various versions in a version switcher
     """
-    language_pairs = sorted((l.tag, l.name) for l in languages if l.in_prod)
+    language_pairs = sorted((l.tag, l.switcher_label) for l in languages if l.in_prod)
     version_pairs = [(v.name, v.picker_label) for v in reversed(versions)]
 
     switchers_template_file = HERE / "templates" / "switchers.js"
@@ -1151,6 +1158,7 @@ def parse_languages_from_config() -> list[Language]:
     """Read config.toml to discover languages to build."""
     config = tomlkit.parse((HERE / "config.toml").read_text(encoding="UTF-8"))
     defaults = config["defaults"]
+    default_translated_name = defaults.get("translated_name", "")
     default_in_prod = defaults.get("in_prod", True)
     default_sphinxopts = defaults.get("sphinxopts", [])
     default_html_only = defaults.get("html_only", False)
@@ -1158,6 +1166,7 @@ def parse_languages_from_config() -> list[Language]:
         Language(
             iso639_tag=iso639_tag,
             name=section["name"],
+            translated_name=section.get("translated_name", default_translated_name),
             in_prod=section.get("in_prod", default_in_prod),
             sphinxopts=section.get("sphinxopts", default_sphinxopts),
             html_only=section.get("html_only", default_html_only),

--- a/config.toml
+++ b/config.toml
@@ -99,7 +99,7 @@ html_only = true
 
 [languages.zh_CN]
 name = "Simplified Chinese"
-translated_name = "简化字"
+translated_name = "简体中文"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -108,7 +108,7 @@ sphinxopts = [
 
 [languages.zh_TW]
 name = "Traditional Chinese"
-translated_name = "繁體字"
+translated_name = "繁體中文"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',

--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ name = "English"
 
 [languages.es]
 name = "Spanish"
-translated_name = "Español"
+translated_name = "español"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -29,7 +29,7 @@ sphinxopts = [
 
 [languages.fr]
 name = "French"
-translated_name = "Français"
+translated_name = "français"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -43,7 +43,7 @@ in_prod = false
 
 [languages.it]
 name = "Italian"
-translated_name = "Italiano"
+translated_name = "italiano"
 
 [languages.ja]
 name = "Japanese"
@@ -81,7 +81,7 @@ sphinxopts = [
 
 [languages.pl]
 name = "Polish"
-translated_name = "Polski"
+translated_name = "polski"
 
 [languages.pt_BR]
 name = "Brazilian Portuguese"
@@ -93,7 +93,7 @@ translated_name = "Türkçe"
 
 [languages.uk]
 name = "Ukrainian"
-translated_name = "Українська"
+translated_name = "українська"
 in_prod = false
 html_only = true
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,12 @@
+# name:            the English name for the language.
+# translated_name: the 'local' name for the language.
+# in_prod:         If true, include in the language switcher.
+# html_only:       If true, only create HTML files.
+# sphinxopts:      Extra options to pass to SPHINXOPTS in the Makefile.
+
 [defaults]
 # name has no default, it is mandatory.
+translated_name = ""
 in_prod = true
 html_only = false
 sphinxopts = [
@@ -13,6 +20,7 @@ name = "English"
 
 [languages.es]
 name = "Spanish"
+translated_name = "Español"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -21,6 +29,7 @@ sphinxopts = [
 
 [languages.fr]
 name = "French"
+translated_name = "Français"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -29,13 +38,16 @@ sphinxopts = [
 
 [languages.id]
 name = "Indonesian"
+translated_name = "Indonesia"
 in_prod = false
 
 [languages.it]
 name = "Italian"
+translated_name = "Italiano"
 
 [languages.ja]
 name = "Japanese"
+translated_name = "日本語"
 sphinxopts = [
     '-D latex_engine=lualatex',
     '-D latex_elements.inputenc=',
@@ -59,6 +71,7 @@ sphinxopts = [
 
 [languages.ko]
 name = "Korean"
+translated_name = "한국어"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -68,20 +81,25 @@ sphinxopts = [
 
 [languages.pl]
 name = "Polish"
+translated_name = "Polski"
 
 [languages.pt_BR]
 name = "Brazilian Portuguese"
+translated_name = "Português Brasileiro"
 
 [languages.tr]
 name = "Turkish"
+translated_name = "Türkçe"
 
 [languages.uk]
 name = "Ukrainian"
+translated_name = "Українська"
 in_prod = false
 html_only = true
 
 [languages.zh_CN]
 name = "Simplified Chinese"
+translated_name = "简化字"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',
@@ -90,6 +108,7 @@ sphinxopts = [
 
 [languages.zh_TW]
 name = "Traditional Chinese"
+translated_name = "簡化字"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',

--- a/config.toml
+++ b/config.toml
@@ -108,7 +108,7 @@ sphinxopts = [
 
 [languages.zh_TW]
 name = "Traditional Chinese"
-translated_name = "簡化字"
+translated_name = "繁體字"
 sphinxopts = [
     '-D latex_engine=xelatex',
     '-D latex_elements.inputenc=',

--- a/config.toml
+++ b/config.toml
@@ -85,7 +85,7 @@ translated_name = "Polski"
 
 [languages.pt_BR]
 name = "Brazilian Portuguese"
-translated_name = "Português Brasileiro"
+translated_name = "Português brasileiro"
 
 [languages.tr]
 name = "Turkish"


### PR DESCRIPTION
An alternative to #244 (closes #244, #238 if merged).

I think it is cleaner to use a new attribute for the local/translated/native name for each language, rather than overloading the `name` field. I agree with @encukou that the English name should come first, and that we should not de-emphasise the other name by using brackets for it.

cc @StanFromIreland @rffontenelle @m-aciek as I can't request you as reviewers.

A