### PR TITLE
Enable Ukranian in the langauge switcher

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -77,7 +77,6 @@ name = "Turkish"
 
 [languages.uk]
 name = "Ukrainian"
-in_prod = false
 html_only = true
 
 [languages.zh_CN]


### PR DESCRIPTION
From a rough check I can see that tutorial is translated and functions are generally (maybe ~98%) translated however I think the fact that the translation is 48.5% translated makes up for this. In comparison Turkish with only 5.1% is included. I think it is a waste of all the effort put in to translated for it to *still* not be in the switcher!

[Source](https://m-aciek.github.io/pydocs-translation-dashboard/)