### PR TITLE
Test Python 3.14 and remove 3.10-1.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.13", "3.14"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
 
     steps:

--- a/build_docs.py
+++ b/build_docs.py
@@ -23,7 +23,7 @@ Modified by Julien Palard to build translations.
 from __future__ import annotations
 
 from argparse import ArgumentParser, Namespace
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from contextlib import suppress, contextmanager
 from dataclasses import dataclass
 import filecmp
@@ -42,7 +42,7 @@ from datetime import datetime as dt, timezone
 from pathlib import Path
 from string import Template
 from time import perf_counter, sleep
-from typing import Iterable, Literal
+from typing import Literal
 from urllib.parse import urljoin
 
 import jinja2
@@ -479,7 +479,7 @@ def version_info():
     """Handler for --version."""
     try:
         platex_version = head(
-            subprocess.check_output(["platex", "--version"], universal_newlines=True),
+            subprocess.check_output(["platex", "--version"], text=True),
             lines=3,
         )
     except FileNotFoundError:
@@ -487,7 +487,7 @@ def version_info():
 
     try:
         xelatex_version = head(
-            subprocess.check_output(["xelatex", "--version"], universal_newlines=True),
+            subprocess.check_output(["xelatex", "--version"], text=True),
             lines=2,
         )
     except FileNotFoundError:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{314, 313, 312, 311, 310}
+    py{314, 313}
 
 [testenv]
 package = wheel

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{313, 312, 311, 310}
+    py{314, 313, 312, 311, 310}
 
 [testenv]
 package = wheel


### PR DESCRIPTION
The docs server is now running Python 3.13: https://github.com/python/psf-salt/pull/551

We can stop testing 3.10-3.12, and let's add 3.14 as well.