### PR TITLE
Add ``--force-build`` to always rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ To manually rebuild a branch, for example 3.11:
 ssh docs.nyc1.psf.io
 sudo su --shell=/bin/bash docsbuild
 screen -DUR  # Rejoin screen session if it exists, otherwise create a new one
-/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --branch 3.11
+/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --force-build --branch 3.11
 ```

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ To manually rebuild a branch, for example 3.11:
 ssh docs.nyc1.psf.io
 sudo su --shell=/bin/bash docsbuild
 screen -DUR  # Rejoin screen session if it exists, otherwise create a new one
-/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --force-build --branch 3.11
+/srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --force --branch 3.11
 ```

--- a/build_docs.py
+++ b/build_docs.py
@@ -806,7 +806,7 @@ class DocBuilder:
             "Publishing done (%s).", format_seconds(perf_counter() - start_time)
         )
 
-    def should_rebuild(self, force_build: bool):
+    def should_rebuild(self, force: bool):
         state = self.load_state()
         if not state:
             logging.info("Should rebuild: no previous state found.")
@@ -834,7 +834,7 @@ class DocBuilder:
                     cpython_sha,
                 )
                 return "Doc/ has changed"
-        if force_build:
+        if force:
             logging.info("Should rebuild: forced.")
             return "forced"
         logging.info("Nothing changed, no rebuild needed.")
@@ -960,7 +960,7 @@ def parse_args():
         default=Path("/srv/docs.python.org"),
     )
     parser.add_argument(
-        "--force-build",
+        "--force",
         action="store_true",
         help="Always build the chosen languages and versions, "
         "regardless of existing state.",
@@ -1083,7 +1083,7 @@ def build_docs(args: argparse.Namespace) -> bool:
         builder = DocBuilder(
             version, versions, language, languages, cpython_repo, **vars(args)
         )
-        built_successfully = builder.run(http, force_build=args.force_build)
+        built_successfully = builder.run(http, force_build=args.force)
         if built_successfully:
             build_succeeded.add((version.name, language.tag))
         elif built_successfully is not None:


### PR DESCRIPTION
This can be useful e.g. when the a new version of the theme is released, or DBS configuration has changed.

Question: Perhaps `--force` instead of `--force-build`?

A