### PR TITLE
Ensure that `Doc/dist` exists

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -802,6 +802,7 @@ class DocBuilder:
         if not self.quick:
             # Copy archive files to /archives/
             logging.debug("Copying dist files.")
+            (self.checkout / "Doc" / "dist").mkdir(exist_ok=True)
             run([
                 "chown",
                 "-R",


### PR DESCRIPTION
For Python 3.12+, we've changed `Doc/Makefile` to add the `dist-html` target. For older versions and the HTML only target, `dist` isn't created, so some commands fail. This ensures that the directory exists.

```
ERROR en/3.11: Run: 'chown -R :docs /srv/docsbuild/cpython-only-html-en/Doc/dist' KO:
    chown: cannot access '/srv/docsbuild/cpython-only-html-en/Doc/dist': No such file or directory
```

A