### PR TITLE
Remove use of the `sed` command

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -687,27 +687,12 @@ class DocBuilder:
                 f"-D ogp_site_url={site_url}",
             )
 
-            def is_gnu_sed() -> bool:
-                """Check if we are using GNU sed."""
-                try:
-                    subprocess.run(
-                        ["sed", "--version"],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        check=True,
-                    )
-                    return True
-                except subprocess.CalledProcessError:
-                    return False
-                except FileNotFoundError:
-                    return False
+            if self.version.as_tuple() < (3, 8):
+                # Disable CPython switchers, we handle them now:
+                text = (self.checkout / "Doc" / "Makefile").read_text(encoding="utf-8")
+                text = text.replace(" -A switchers=1", "")
+                (self.checkout / "Doc" / "Makefile").write_text(text, encoding="utf-8")
 
-            # Disable CPython switchers, we handle them now:
-            run(
-                ["sed", "-i"]
-                + ([] if is_gnu_sed() else [""])
-                + ["s/ *-A switchers=1//", self.checkout / "Doc" / "Makefile"]
-            )
             self.versions.setup_indexsidebar(
                 self.version,
                 self.checkout / "Doc" / "tools" / "templates" / "indexsidebar.html",

--- a/build_docs.py
+++ b/build_docs.py
@@ -646,21 +646,6 @@ class DocBuilder:
                 "-D gettext_compact=0",
                 "-D translation_progress_classes=1",
             ))
-        if self.language.tag == "ja":
-            # Since luatex doesn't support \ufffd, replace \ufffd with '?'.
-            # https://gist.github.com/zr-tex8r/e0931df922f38fbb67634f05dfdaf66b
-            # Luatex already fixed this issue, so we can remove this once Texlive
-            # is updated.
-            # (https://github.com/TeX-Live/luatex/commit/af5faf1)
-            subprocess.check_output(
-                "sed -i s/\N{REPLACEMENT CHARACTER}/?/g "
-                f"{locale_dirs}/ja/LC_MESSAGES/**/*.po",
-                shell=True,
-            )
-            subprocess.check_output(
-                f"sed -i s/\N{REPLACEMENT CHARACTER}/?/g {self.checkout}/Doc/**/*.rst",
-                shell=True,
-            )
 
         if self.version.status == "EOL":
             sphinxopts.append("-D html_context.outdated=1")


### PR DESCRIPTION
As noted in the comment, this was fixed [1] and released in LuaTex 1.16.

\[1]: https://gitlab.lisn.upsaclay.fr/texlive/luatex/-/commit/af5faf1af25dc00f02356eb0e99bfe26b8de2f61

We have LuaTex 1.17 on the server:

```
adam@docs:/srv/docsbuild/scripts$ luatex -credits
This is LuaTeX, Version 1.17.0 (TeX Live 2023/Debian)
[...]

Development id: 7581
```