### PR TITLE
Only copy archive files if the dist directory exists

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -784,10 +784,9 @@ class DocBuilder:
                 target,
             ])
 
-        if not self.quick:
+        if not self.quick and (self.checkout / "Doc" / "dist").is_dir():
             # Copy archive files to /archives/
             logging.debug("Copying dist files.")
-            (self.checkout / "Doc" / "dist").mkdir(exist_ok=True)
             run([
                 "chown",
                 "-R",


### PR DESCRIPTION
#271 led to a new error, `cp: missing destination file operand after '/srv/docs.python.org/3.9/archives'`.