### PR TITLE
Simplify generation of `indexsidebar.html`

### DIFF
--- a/templates/_docs_by_version.html
+++ b/templates/_docs_by_version.html
@@ -1,0 +1,11 @@
+{#
+This file is only used in indexsidebar.html, where it is included in the docs
+by version list. For non-end-of-life branches, build_docs.py overwrites this
+list with the full list of versions.
+
+Keep the following two files synchronised:
+* cpython/Doc/tools/templates/_docs_by_version.html
+* docsbuild-scripts/templates/_docs_by_version.html
+#}
+<li><a href="https://docs.python.org/3/">{% trans %}Stable{% endtrans %}</a></li>
+<li><a href="https://docs.python.org/dev/">{% trans %}In development{% endtrans %}</a></li>

--- a/templates/indexsidebar.html
+++ b/templates/indexsidebar.html
@@ -1,30 +1,18 @@
 {#
-Beware, this file is rendered twice via Jinja2:
-- First by build_docs.py, given 'current_version' and 'versions'.
-- A 2nd time by Sphinx.
+Beware, this file is rendered twice:
+- First by build_docs.py using string.Template, given '$DOCS_BY_VERSION'.
+- Second time by Sphinx, using Jinja.
 #}
 
-{% raw %}
 <h3>{% trans %}Download{% endtrans %}</h3>
 <p><a href="{{ pathto('download') }}">{% trans %}Download these documents{% endtrans %}</a></p>
-{% endraw %}
-{% if current_version.status != "EOL" %}
-{% raw %}<h3>{% trans %}Docs by version{% endtrans %}</h3>{% endraw %}
-<ul>
-  {% for version in versions %}
-  <li><a href="{{ version.url }}">{{ version.title }}</a></li>
-  {% endfor %}
-  {% raw %}<li><a href="https://www.python.org/doc/versions/">{% trans %}All versions{% endtrans %}</a></li>{% endraw %}
-</ul>
-{% endif %}
-{% raw %}
+$DOCS_BY_VERSION
 <h3>{% trans %}Other resources{% endtrans %}</h3>
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}
-  <li><a href="https://peps.python.org">{% trans %}PEP Index{% endtrans %}</a></li>
+  <li><a href="https://peps.python.org/">{% trans %}PEP Index{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/BeginnersGuide">{% trans %}Beginner's Guide{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/PythonBooks">{% trans %}Book List{% endtrans %}</a></li>
   <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/Visual Talks{% endtrans %}</a></li>
   <li><a href="https://devguide.python.org/">{% trans %}Python Developer’s Guide{% endtrans %}</a></li>
 </ul>
-{% endraw %}

--- a/templates/indexsidebar.html
+++ b/templates/indexsidebar.html
@@ -1,12 +1,11 @@
-{#
-Beware, this file is rendered twice:
-- First by build_docs.py using string.Template, given '$DOCS_BY_VERSION'.
-- Second time by Sphinx, using Jinja.
-#}
-
 <h3>{% trans %}Download{% endtrans %}</h3>
 <p><a href="{{ pathto('download') }}">{% trans %}Download these documents{% endtrans %}</a></p>
-$DOCS_BY_VERSION
+<h3>{% trans %}Docs by version{% endtrans %}</h3>
+<ul>
+  {# _docs_by_version.html is overwritten by build_docs.py for non-EOL versions #}
+  {% include "_docs_by_version.html" without context %}
+  <li><a href="https://www.python.org/doc/versions/">{% trans %}All versions{% endtrans %}</a></li>
+</ul>
 <h3>{% trans %}Other resources{% endtrans %}</h3>
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}


### PR DESCRIPTION
Remove the double-rendering of `indexsidebar.html`. For end-of-life versions, change the sidebar to contain a link to the current stable version. For non-EOL versions, overwrite the new `_docs_by_version.html` file with the list of links.

This also means that we can now remove `versions` as an argument to `DocBuilder`.

A