### PR TITLE
Run unit tests on three operating systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,14 @@ jobs:
 
   unit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version:
         - "3.13"
         - "3.14"
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -69,5 +70,6 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v5
       with:
+        flags: ${{ matrix.os }}
         name: Python ${{ matrix.python-version }}
         token: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,22 +13,14 @@ env:
 jobs:
   integration:
     name: Integration test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13", "3.14"]
-        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+        python-version: "3.13"
 
     - name: Set up requirements
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,24 @@ env:
 jobs:
   integration:
     name: Integration test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.13"
+        - "3.14"
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v5
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Set up requirements
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - "3.13"
-        - "3.14"
+        python-version: ["3.13", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -55,9 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - "3.13"
-        - "3.14"
+        python-version: ["3.13", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
After removing sed in https://github.com/python/docsbuild-scripts/pull/272, we should now support Windows in addition to Linux and macOS?

Let's test them to avoid regressions.
