### PR TITLE
Constrain blurb to version 1.1 or older

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -194,7 +194,7 @@ class Version:
             return dependencies + ["standard-imghdr"]
 
         # Requirements/constraints for Python 3.7 and older, pre-requirements.txt
-        reqs = ["jieba", "blurb", "jinja2<3.1", "docutils<=0.17.1", "standard-imghdr"]
+        reqs = ["jieba", "blurb<1.2", "jinja2<3.1", "docutils<0.18", "standard-imghdr"]
         if self.name in {"3.7", "3.6", "2.7"}:
             return reqs + ["sphinx==2.3.1"]
         if self.name == "3.5":


### PR DESCRIPTION
Rebuilding 3.5, 3.6, and 3.7 fail with the following error. Try constraining them to a previous version of blurb.

```pytb
Traceback (most recent call last):
  File "/srv/docsbuild/venv-3.7/bin/blurb", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 1203, in main
    sys.exit(fn(*filtered_args, **kwargs))
             ~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 982, in merge
    write_news(output, versions=versions)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 1014, in write_news
    blurbs.load(filenames[0])
    ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 536, in load
    self.parse(text, metadata=metadata, filename=filename)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 526, in parse
    finish_entry()
    ~~~~~~~~~~~~^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 497, in finish_entry
    throw("No 'section' specified.  You must provide one!")
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/docsbuild/venv-3.7/lib/python3.13/site-packages/blurb/blurb.py", line 446, in throw
    raise BlurbError(f"Error in {filename}:{line_number}:\n{s}")
blurb.blurb.BlurbError: Error in Misc/NEWS.d/3.6.2.rst:7:
No 'section' specified.  You must provide one!
```