### PR TITLE
Enable ``suggest_on_error`` for argparse

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -967,7 +967,6 @@ def parse_args() -> argparse.Namespace:
         description="Runs a build of the Python docs for various branches.",
         allow_abbrev=False,
     )
-    parser.color = True
     parser.suggest_on_error = True
     parser.add_argument(
         "--select-output",

--- a/build_docs.py
+++ b/build_docs.py
@@ -967,6 +967,8 @@ def parse_args() -> argparse.Namespace:
         description="Runs a build of the Python docs for various branches.",
         allow_abbrev=False,
     )
+    parser.color = True
+    parser.suggest_on_error = True
     parser.add_argument(
         "--select-output",
         choices=("no-html", "only-html", "only-html-en"),


### PR DESCRIPTION
These options are new in Python 3.14.

# Before

<img width="962" alt="image" src="https://github.com/user-attachments/assets/06777f1e-9d18-49b8-b832-cff59475f96d" />

# After

<img width="962" alt="image" src="https://github.com/user-attachments/assets/5e845426-383c-462a-8f4d-42b408ddb616" />


Docs:

* https://docs.python.org/3.14/library/argparse.html#suggest-on-error
* https://docs.python.org/3.14/library/argparse.html#color