### PR TITLE
Add options to only show certain build times

### DIFF
--- a/check_times.py
+++ b/check_times.py
@@ -82,34 +82,32 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    ALL_BUILDS = ("no-html", "only-html", "only-html-en")
     parser.add_argument(
-        "--html-en", action="store_true", help="Show HTML-only (English) build times"
-    )
-    parser.add_argument(
-        "--html", action="store_true", help="Show HTML-only build times"
-    )
-    parser.add_argument(
-        "--no-html", action="store_true", help="Show no-HTML build times"
+        "--select-output",
+        choices=ALL_BUILDS,
+        nargs="*",
+        help="Choose what builds to show (default: all).",
     )
     args = parser.parse_args()
+    parser.suggest_on_error = True
 
-    # If none specified, show all
-    if not (args.html_en or args.html or args.no_html):
-        args.html_en = args.html = args.no_html = True
+    if not args.select_output:
+        args.select_output = ALL_BUILDS
 
-    if args.html_en:
+    if "only-html-en" in args.select_output:
         print("Build times (HTML only; English)")
         print("=======================")
         print()
         calc_time(get_lines("docsbuild-only-html-en.log"))
 
-    if args.html:
+    if "only-html" in args.select_output:
         print("Build times (HTML only)")
         print("=======================")
         print()
         calc_time(get_lines("docsbuild-only-html.log"))
 
-    if args.no_html:
+    if "no-html" in args.select_output:
         print("Build times (no HTML)")
         print("=====================")
         print()

--- a/check_times.py
+++ b/check_times.py
@@ -10,6 +10,7 @@ For example:
    $ python check_times.py
 """
 
+import argparse
 import gzip
 import tomllib
 from pathlib import Path
@@ -78,17 +79,38 @@ def calc_time(lines: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    print("Build times (HTML only; English)")
-    print("=======================")
-    print()
-    calc_time(get_lines("docsbuild-only-html-en.log"))
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--html-en", action="store_true", help="Show HTML-only (English) build times"
+    )
+    parser.add_argument(
+        "--html", action="store_true", help="Show HTML-only build times"
+    )
+    parser.add_argument(
+        "--no-html", action="store_true", help="Show no-HTML build times"
+    )
+    args = parser.parse_args()
 
-    print("Build times (HTML only)")
-    print("=======================")
-    print()
-    calc_time(get_lines("docsbuild-only-html.log"))
+    # If none specified, show all
+    if not (args.html_en or args.html or args.no_html):
+        args.html_en = args.html = args.no_html = True
 
-    print("Build times (no HTML)")
-    print("=====================")
-    print()
-    calc_time(get_lines("docsbuild-no-html.log"))
+    if args.html_en:
+        print("Build times (HTML only; English)")
+        print("=======================")
+        print()
+        calc_time(get_lines("docsbuild-only-html-en.log"))
+
+    if args.html:
+        print("Build times (HTML only)")
+        print("=======================")
+        print()
+        calc_time(get_lines("docsbuild-only-html.log"))
+
+    if args.no_html:
+        print("Build times (no HTML)")
+        print("=====================")
+        print()
+        calc_time(get_lines("docsbuild-no-html.log"))


### PR DESCRIPTION
By default, this scripts outputs the build times for all three types of builds. This can be long, for example 1,582 lines.

Sometimes I only want to check one block, for example, non-HTML builds in https://github.com/python/docsbuild-scripts/issues/306.

This PR allows you to select which type of build. By default, it shows all three.
