### PR TITLE
The Romanian translation is now ready for the translation switcher

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -99,7 +99,6 @@ translated_name = "Português brasileiro"
 [languages.ro]
 name = "Romanian"
 translated_name = "Românește"
-in_prod = false
 
 [languages.tr]
 name = "Turkish"


### PR DESCRIPTION
The Romanian translation is now ready for the translation switcher. It targets the "3.13" branch of the docs (repository).