### PR TITLE
Add Romanian translation to the language switcher

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -99,7 +99,6 @@ translated_name = "Português brasileiro"
 [languages.ro]
 name = "Romanian"
 translated_name = "Românește"
-in_prod = false
 
 [languages.tr]
 name = "Turkish"

--- a/config.toml
+++ b/config.toml
@@ -99,6 +99,7 @@ translated_name = "Português brasileiro"
 [languages.ro]
 name = "Romanian"
 translated_name = "Românește"
+in_prod = false
 
 [languages.tr]
 name = "Turkish"


### PR DESCRIPTION
I prepared the translation for the translation switcher. The repository contains a Romanian translation of: [ bugs.po, tutorial/*.po, library/functions.po ]. It also includes some necessary partial translations to make the Romanian version of the tutorial easier to use: [ glossary.po (only the index), sphinx.po (the fragments used for the splash-page and for the download page) ]. I have tested the translation against the latest docs from the [Python/cpython, branch 3.13](https://github.com/python/cpython/tree/3.13).