### PR TITLE
Add `aria-label`s to switchers

### DIFF
--- a/templates/switchers.js
+++ b/templates/switchers.js
@@ -63,6 +63,7 @@ const _create_placeholders_if_missing = () => {
 const _create_version_select = (versions) => {
   const select = document.createElement("select");
   select.className = "version-select";
+  select.setAttribute("aria-label", "Python version");
   if (_IS_LOCAL) {
     select.disabled = true;
     select.title = "Version switching is disabled in local builds";
@@ -96,6 +97,7 @@ const _create_language_select = (languages) => {
 
   const select = document.createElement("select");
   select.className = "language-select";
+  select.setAttribute("aria-label", "Language");
   if (_IS_LOCAL) {
     select.disabled = true;
     select.title = "Language switching is disabled in local builds";


### PR DESCRIPTION
Per Lighthouse:

<img width="977" height="430" alt="image" src="https://github.com/user-attachments/assets/da65cf0c-7c5c-4964-96c1-3d336e57459e" />

We actually already did this for RTD builds some time ago in https://github.com/python/cpython/commit/1306f33c84b2745aa8af5e3e8f680aa80b836c0e.