### PR TITLE
Add Russian translation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -103,6 +103,10 @@ translated_name = "Português brasileiro"
 name = "Romanian"
 translated_name = "Românește"
 
+[languages.ru]
+name = "Russian"
+translated_name = "Русский"
+
 [languages.sv]
 name = "Swedish"
 translated_name = "Svenska"


### PR DESCRIPTION
Russian is ready to be added to the switcher. 🎉
The necessary pages have been translated.