### PR TITLE
Don't include analyitics in download copies

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -1009,6 +1009,8 @@ def main() -> int:
     if args.select_output is None:
         return build_docs_with_lock(args, "build_docs.lock")
     if args.select_output == "no-html":
+        # Disable Plausible analytics for download copies
+        os.environ.pop("PYTHON_DOCS_ENABLE_ANALYTICS", None)
         return build_docs_with_lock(args, "build_docs_archives.lock")
     if args.select_output == "only-html":
         return build_docs_with_lock(args, "build_docs_html.lock")


### PR DESCRIPTION
I think. To be honest the `no-html` option building the HTML (IIUC) is a tad confusing. This fixes https://github.com/python/cpython/issues/136194.