### PR TITLE
Recreate venv for each build + install from pylock.toml when available

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -641,6 +641,7 @@ class DocBuilder:
     cpython_repo: Repository
     docs_by_version_content: bytes
     switchers_content: bytes
+    built_venvs: set[Path]
     build_root: Path
     www_root: Path
     select_output: Literal["no-html", "only-html", "only-html-en"] | None
@@ -804,22 +805,28 @@ class DocBuilder:
     def build_venv(self) -> None:
         """Build a venv for the specific Python version.
 
-        The venv is recreated from scratch for every build: pip considers
-        a requirement satisfied when the installed version number matches,
-        even if the requirement is a direct URL now pointing at different
-        code, so a reused venv can silently keep outdated packages.
+        The venv is created at most once per run and reused by later
+        builds of the same version: reusing a venv across runs can
+        silently keep outdated packages, because pip considers a
+        requirement satisfied when the installed version number matches,
+        even if the requirement is a direct URL now pointing at
+        different code.
         """
-        requirements = list(self.build_meta.dependencies)
-        if self.includes_html:
-            # opengraph previews
-            requirements.append("matplotlib>=3")
-
         venv_name = self.build_meta.venv_name
         if self.select_output is not None:
             # Never share a venv with a concurrent differently-selected
             # build, which may recreate it mid-build.
             venv_name += f"-{self.select_output}"
         venv_path = self.build_root / venv_name
+        if venv_path in self.built_venvs:
+            self.venv = venv_path
+            return
+
+        requirements = list(self.build_meta.dependencies)
+        if self.includes_html:
+            # opengraph previews
+            requirements.append("matplotlib>=3")
+
         venv.create(
             venv_path,
             symlinks=os.name != "nt",
@@ -840,6 +847,7 @@ class DocBuilder:
             cwd=self.checkout / "Doc",
         )
         run((python, "-m", "pip", "freeze", "--all"))
+        self.built_venvs.add(venv_path)
         self.venv = venv_path
 
     def setup_indexsidebar(self) -> None:
@@ -1275,6 +1283,7 @@ def build_docs(args: argparse.Namespace) -> int:
         "https://github.com/python/cpython.git",
         args.build_root / _checkout_name(args.select_output),
     )
+    built_venvs: set[Path] = set()
     while todo:
         build_props = todo.pop()
         logging.root.handlers[0].setFormatter(
@@ -1292,6 +1301,7 @@ def build_docs(args: argparse.Namespace) -> int:
             cpython_repo,
             docs_by_version_content,
             switchers_content,
+            built_venvs,
             **vars(args),
         )
         built_successfully = builder.run(http, force_build=force_build)

--- a/build_docs.py
+++ b/build_docs.py
@@ -804,24 +804,30 @@ class DocBuilder:
     def build_venv(self) -> None:
         """Build a venv for the specific Python version.
 
-        So we can reuse them from builds to builds, while they contain
-        different Sphinx versions.
+        The venv is recreated from scratch for every build: pip considers
+        a requirement satisfied when the installed version number matches,
+        even if the requirement is a direct URL now pointing at different
+        code, so a reused venv can silently keep outdated packages
+        (see python/cpython#153227).
         """
         requirements = list(self.build_meta.dependencies)
         if self.includes_html:
             # opengraph previews
             requirements.append("matplotlib>=3")
 
-        venv_path = self.build_root / self.build_meta.venv_name
-        venv.create(venv_path, symlinks=os.name != "nt", with_pip=True)
+        venv_name = self.build_meta.venv_name
+        if self.select_output is not None:
+            # Never share a venv with a concurrent differently-selected
+            # build, which may recreate it mid-build.
+            venv_name += f"-{self.select_output}"
+        venv_path = self.build_root / venv_name
+        venv.create(venv_path, symlinks=os.name != "nt", with_pip=True, clear=True)
         run(
             (
                 venv_path / "bin" / "python",
                 "-m",
                 "pip",
                 "install",
-                "--upgrade",
-                "--upgrade-strategy=eager",
                 self.theme,
                 *requirements,
             ),

--- a/build_docs.py
+++ b/build_docs.py
@@ -805,12 +805,12 @@ class DocBuilder:
     def build_venv(self) -> None:
         """Build a venv for the specific Python version.
 
-        The venv is created at most once per run and reused by later
-        builds of the same version: reusing a venv across runs can
-        silently keep outdated packages, because pip considers a
-        requirement satisfied when the installed version number matches,
-        even if the requirement is a direct URL now pointing at
-        different code.
+        The venv is created at most once per run, reused by later builds
+        of the same version, and removed at the end of the run: reusing
+        a venv across runs can silently keep outdated packages, because
+        pip considers a requirement satisfied when the installed version
+        number matches, even if the requirement is a direct URL now
+        pointing at different code.
         """
         venv_name = self.build_meta.venv_name
         if self.select_output is not None:
@@ -1284,31 +1284,35 @@ def build_docs(args: argparse.Namespace) -> int:
         args.build_root / _checkout_name(args.select_output),
     )
     built_venvs: set[Path] = set()
-    while todo:
-        build_props = todo.pop()
-        logging.root.handlers[0].setFormatter(
-            logging.Formatter(
-                f"%(asctime)s %(levelname)s {build_props.slug}: %(message)s"
+    try:
+        while todo:
+            build_props = todo.pop()
+            logging.root.handlers[0].setFormatter(
+                logging.Formatter(
+                    f"%(asctime)s %(levelname)s {build_props.slug}: %(message)s"
+                )
             )
-        )
-        if sentry_sdk:
-            scope = sentry_sdk.get_isolation_scope()
-            scope.set_tag("version", build_props.version)
-            scope.set_tag("language", build_props.language)
-        cpython_repo.update()
-        builder = DocBuilder(
-            build_props,
-            cpython_repo,
-            docs_by_version_content,
-            switchers_content,
-            built_venvs,
-            **vars(args),
-        )
-        built_successfully = builder.run(http, force_build=force_build)
-        if built_successfully:
-            build_succeeded.add(build_props.slug)
-        elif built_successfully is not None:
-            any_build_failed = True
+            if sentry_sdk:
+                scope = sentry_sdk.get_isolation_scope()
+                scope.set_tag("version", build_props.version)
+                scope.set_tag("language", build_props.language)
+            cpython_repo.update()
+            builder = DocBuilder(
+                build_props,
+                cpython_repo,
+                docs_by_version_content,
+                switchers_content,
+                built_venvs,
+                **vars(args),
+            )
+            built_successfully = builder.run(http, force_build=force_build)
+            if built_successfully:
+                build_succeeded.add(build_props.slug)
+            elif built_successfully is not None:
+                any_build_failed = True
+    finally:
+        for venv_path in built_venvs:
+            shutil.rmtree(venv_path, ignore_errors=True)
 
     logging.root.handlers[0].setFormatter(
         logging.Formatter("%(asctime)s %(levelname)s: %(message)s")

--- a/build_docs.py
+++ b/build_docs.py
@@ -822,18 +822,20 @@ class DocBuilder:
             venv_name += f"-{self.select_output}"
         venv_path = self.build_root / venv_name
         venv.create(venv_path, symlinks=os.name != "nt", with_pip=True, clear=True)
+        python = venv_path / "bin" / "python"
+        run((python, "-m", "pip", "install", "--upgrade", "pip"))
+
+        if (self.checkout / "Doc" / "pylock.toml").exists():
+            requirements.remove("-rrequirements.txt")
+            run(
+                (python, "-m", "pip", "install", "-rpylock.toml"),
+                cwd=self.checkout / "Doc",
+            )
         run(
-            (
-                venv_path / "bin" / "python",
-                "-m",
-                "pip",
-                "install",
-                self.theme,
-                *requirements,
-            ),
+            (python, "-m", "pip", "install", self.theme, *requirements),
             cwd=self.checkout / "Doc",
         )
-        run((venv_path / "bin" / "python", "-m", "pip", "freeze", "--all"))
+        run((python, "-m", "pip", "freeze", "--all"))
         self.venv = venv_path
 
     def setup_indexsidebar(self) -> None:

--- a/build_docs.py
+++ b/build_docs.py
@@ -821,9 +821,14 @@ class DocBuilder:
             # build, which may recreate it mid-build.
             venv_name += f"-{self.select_output}"
         venv_path = self.build_root / venv_name
-        venv.create(venv_path, symlinks=os.name != "nt", with_pip=True, clear=True)
+        venv.create(
+            venv_path,
+            symlinks=os.name != "nt",
+            with_pip=True,
+            clear=True,
+            upgrade_deps=True,
+        )
         python = venv_path / "bin" / "python"
-        run((python, "-m", "pip", "install", "--upgrade", "pip"))
 
         if (self.checkout / "Doc" / "pylock.toml").exists():
             requirements.remove("-rrequirements.txt")

--- a/build_docs.py
+++ b/build_docs.py
@@ -836,7 +836,7 @@ class DocBuilder:
         )
         python = venv_path / "bin" / "python"
 
-        if (self.checkout / "Doc" / "pylock.toml").exists():
+        if (self.checkout / "Doc" / "pylock.toml").is_file():
             requirements.remove("-rrequirements.txt")
             run(
                 (python, "-m", "pip", "install", "-rpylock.toml"),

--- a/build_docs.py
+++ b/build_docs.py
@@ -807,8 +807,7 @@ class DocBuilder:
         The venv is recreated from scratch for every build: pip considers
         a requirement satisfied when the installed version number matches,
         even if the requirement is a direct URL now pointing at different
-        code, so a reused venv can silently keep outdated packages
-        (see python/cpython#153227).
+        code, so a reused venv can silently keep outdated packages.
         """
         requirements = list(self.build_meta.dependencies)
         if self.includes_html:


### PR DESCRIPTION
Re: https://github.com/python/cpython/issues/153227#issuecomment-5107264828

https://github.com/python/cpython/pull/153228 switched to use a dev version of pygments from GitHub, but it's not being picked up on the doc server.

This is because:

* We re-use a venv per Python version on the docs server
*  `pip install --upgrade -rrequirements.txt` still sees pygments with the same version number in the venv, so doesn't need to upgrade it

This PR does two things:

* Clear the venv for each build. We still have a pip cache on the server, so it's not downloading everything every time. This means we'll always a fresh venv matching what we expect.
* We now have pylock.toml on newer branches (3.15+), which locks the actual required version, so this explicitly pin the dev version from GitHub. Let's use `pylock.toml` when when available.
