### PR TITLE
build(deps): pin GitPython>=3.1.58 to resolve GHSA-9rj7-rf2p-w77r, GHSA-wvpp-8hx9-p66j

### DIFF
--- a/tools_requirements.txt
+++ b/tools_requirements.txt
@@ -1,4 +1,4 @@
-GitPython
+GitPython>=3.1.58
 httpx
 tabulate
 zc.lockfile


### PR DESCRIPTION
## Summary

Pin minimum GitPython version in `tools_requirements.txt` to resolve two recent HIGH-severity advisories:

- **GHSA-9rj7-rf2p-w77r**: `Repo.init()` forwards `**kwargs` to `git init` with no unsafe-option guard. An attacker-controlled `template` kwarg can plant hooks that execute on the next git operation, enabling arbitrary command execution.

- **GHSA-wvpp-8hx9-p66j**: The `check_unsafe_options` guard can be bypassed on all guarded methods via `split_single_char_options=False` short-option token smuggling, enabling command execution at default `allow_unsafe_options=False`.

Both fixed in [GitPython 3.1.58](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.58).

## Change

```diff
-GitPython
+GitPython>=3.1.58
```

Single line change in `tools_requirements.txt`. No application logic affected.

## Verification

Scanned with osv-scanner before and after:

- **Before**: 22 GitPython advisories flagged (including GHSA-9rj7-rf2p-w77r, GHSA-wvpp-8hx9-p66j, PYSEC-2026-2161, PYSEC-2023-137, and others)
- **After**: 0 GitPython advisories. All 22 cleared. Only unrelated httpx advisory (PYSEC-2022-183) remains.