### PR TITLE
Add Persian translation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -99,6 +99,10 @@ translated_name = "polski"
 name = "Brazilian Portuguese"
 translated_name = "Português brasileiro"
 
+[languages.fa]
+name = "Persian"
+translated_name = "فارسی"
+
 [languages.ro]
 name = "Romanian"
 translated_name = "Românește"

--- a/config.toml
+++ b/config.toml
@@ -102,6 +102,9 @@ translated_name = "Português brasileiro"
 [languages.fa]
 name = "Persian"
 translated_name = "فارسی"
+sphinxopts = [
+    '-D html_theme_options.is_rtl=true',
+]
 
 [languages.ro]
 name = "Romanian"


### PR DESCRIPTION
Add Persian (Farsi) to the language switcher.
Translation repo: https://github.com/python/python-docs-fa
Please let me know if any changes are needed :)