### PR TITLE
Fix combined builds missing HTML output

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -756,8 +756,14 @@ class DocBuilder:
         else:
             maketarget = "autobuild-stable"
         if self.html_only:
-            maketarget += "-html"
-        logging.info("Running make %s", maketarget)
+            maketargets = [f"{maketarget}-html"]
+        else:
+            maketargets = [maketarget]
+            if self.includes_html and self.build_meta.version_tuple >= (3, 9):
+                # Since 3.9, the plain autobuild targets only build non-HTML
+                # (gh-139436), but a combined build needs HTML.
+                maketargets.append(f"{maketarget}-html")
+        logging.info("Running make %s", " ".join(maketargets))
         python = self.venv / "bin" / "python"
         sphinxbuild = self.venv / "bin" / "sphinx-build"
         blurb = self.venv / "bin" / "blurb"
@@ -792,7 +798,7 @@ class DocBuilder:
             f"VENVDIR={self.venv}",
             f"SPHINXOPTS={' '.join(sphinxopts)}",
             "SPHINXERRORHANDLING=",
-            maketarget,
+            *maketargets,
         ))
         self.log_directory.mkdir(parents=True, exist_ok=True)
         chgrp(self.log_directory, group=self.group, recursive=True)

--- a/build_docs.py
+++ b/build_docs.py
@@ -759,8 +759,8 @@ class DocBuilder:
             maketargets = [f"{maketarget}-html"]
         else:
             maketargets = [maketarget]
-            if self.includes_html and self.build_meta.version_tuple >= (3, 9):
-                # Since 3.9, the plain autobuild targets only build non-HTML
+            if self.includes_html:
+                # The plain autobuild targets only build non-HTML
                 # (gh-139436), but a combined build needs HTML.
                 maketargets.append(f"{maketarget}-html")
         logging.info("Running make %s", " ".join(maketargets))


### PR DESCRIPTION
https://github.com/python/cpython/commit/9104fc6cdff8513fb22c426da2c629c5832fc331 made `make autobuild-stable` build only the non-HTML archives via `dist-no-html`, whereas previously the `dist` target had built HTML too. `build_docs.py` in the combined mode (no `--select-output`, as suggested in the README) still expects `Doc/build/html/` to exist after that target, so `setup_switchers()` crashed with `FileNotFoundError` writing `_static/switchers.js`. Reported by Sentry at https://python-software-foundation.sentry.io/issues/7712785037/.